### PR TITLE
fix: footer navigation overflows on small screens

### DIFF
--- a/apps/classroomio-com/src/lib/Footer/Footer.svelte
+++ b/apps/classroomio-com/src/lib/Footer/Footer.svelte
@@ -58,7 +58,7 @@
     </div>
 
     <nav
-      class="mt-16 flex w-full min-w-[400px] flex-col items-start justify-end gap-12 space-y-6 lg:mt-0 lg:w-3/4 lg:flex-row lg:space-y-0"
+      class="mt-16 flex w-full min-w-0 sm:min-w-[200px] flex-col items-start justify-end gap-12 space-y-6 lg:mt-0 lg:w-3/4 lg:flex-row lg:space-y-0"
     >
       <div class="max-w-[120px]">
         <p class="lg:text-base mb-3 text-base font-semibold leading-6 text-gray-900 lg:mb-10">


### PR DESCRIPTION
## What does this PR do?

This PR Fixes the footer navigation overflow issue on small screens.

Fixes #598 

<!-- Please provide a screenshots or upload a video for visual changes to speed up reviews -->
<img width="439" height="765" alt="footer" src="https://github.com/user-attachments/assets/15523ab3-6436-46cf-bc14-9bdfd546a2cc" />

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Go to the landing page on a small/mobile screen
- Check that the footer navigation no longer overflows horizontally
- Verify responsiveness across breakpoints (sm, md)

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary
