### PR TITLE
fix: Api build and environment

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -21,3 +21,6 @@ SENTRY_DNS=
 OPENAPI_URL=
 
 PRIVATE_SERVER_KEY=
+
+# Public API URL (used for absolute URLs in emails, redirects, etc.)
+PUBLIC_SERVER_URL=


### PR DESCRIPTION
## What does this PR do?

This PR addresses a potential issue where the API server URL could default to `localhost` in production environments. It ensures that the `PUBLIC_SERVER_URL` environment variable is documented in `apps/api/.env.example`, preventing incorrect API base URLs.

Fixes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

-   Start the API server.
-   Verify that `API_SERVER_URL` correctly reflects the value set for `PUBLIC_SERVER_URL` in the `.env` file.
-   Ensure that any features relying on the external API base URL (e.g., generated links) function as expected.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build` (implicitly handled by `tsc` in `build` script)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

---