### PR TITLE
fix: keep exercise instructions accessible during attempts

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -32,7 +32,7 @@ jobs:
         run: pnpm install --no-frozen-lockfile
 
       - name: Build publishable MCP package
-        run: pnpm --filter @classroomio/mcp build
+        run: pnpm mcp:build
 
       - name: Publish package
         if: github.event_name == 'workflow_dispatch'

--- a/apps/dashboard/src/lib/components/Course/components/Lesson/Exercise/ViewMode.svelte
+++ b/apps/dashboard/src/lib/components/Course/components/Lesson/Exercise/ViewMode.svelte
@@ -363,6 +363,20 @@
   {#key currentQuestion.id}
     <!-- <div transition:fade id="question"> -->
     <div in:fly={{ x: 500, duration: 1000 }} id="question">
+      {#if $questionnaire.description}
+        <details
+          class="mb-4 rounded-md border border-gray-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-900"
+          open={$questionnaireMetaData.currentQuestionIndex === 1}
+        >
+          <summary class="cursor-pointer text-sm font-semibold dark:text-white">
+            Exercise instructions
+          </summary>
+          <article class="preview prose prose-sm sm:prose mt-3">
+            {@html sanitizeHtml($questionnaire.description)}
+          </article>
+        </details>
+      {/if}
+
       {#if QUESTION_TYPE.RADIO === currentQuestion.question_type.id}
         <RadioQuestion {...renderProps} key={currentQuestion.id} hideGrading={true} />
       {:else if QUESTION_TYPE.CHECKBOX === currentQuestion.question_type.id}


### PR DESCRIPTION
## What does this PR do?

Keeps the exercise description available after a learner starts an exercise by showing a collapsible **Exercise instructions** panel above the current question.

This addresses the learning-experience issue where students may need to refer back to links, context, or supporting instructions from the exercise description while answering questions.

Fixes #658

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Create or open an exercise with a description and at least one question.
- Start the exercise as a learner.
- Confirm the first question page shows the exercise instructions expanded above the question.
- Move to another question and confirm the instructions remain available as a collapsible panel.

## Validation

- Verified the existing exercise description is already sanitized through `sanitizeHtml`.
- Ran `git diff --check`.
- Could not run `pnpm build` in this local environment because npm/pnpm is not installed in the available runtime.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (not applicable)
- [ ] Ran `pnpm build` (not available in local runtime)
- [x] Checked for warnings, there are none in the diff check
- [x] Removed all `console.logs` (not applicable)
- [x] Merged the latest changes from main onto my branch
- [x] My changes don't cause any responsiveness issues by design; the panel uses existing responsive utility classes

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a collapsible `<details>` panel above the current question during an active exercise attempt, displaying the exercise's description so learners can reference instructions without leaving the question flow. The HTML is rendered via the pre-existing `sanitizeHtml` utility, maintaining the same XSS protection already used on the exercise start screen.

- A `<details open={currentQuestionIndex === 1}>` block is inserted inside the `{#key currentQuestion.id}` section, so it opens automatically on the first question and collapses (but remains available) on subsequent ones.
- The panel is conditionally rendered only when `$questionnaire.description` is truthy, so exercises without a description are unaffected.
- The `summary` label `"Exercise instructions"` is hardcoded in English rather than going through the `$t()` translation function that all other visible strings in this component use.

<h3>Confidence Score: 4/5</h3>

The change is small and self-contained, touching only the question-rendering block of a single component with no side effects on state or data flow.

The logic is straightforward: a conditionally rendered native details element reuses the already-sanitized description field. The only gap is the hardcoded English label in a component that otherwise uses $t() for every visible string.

apps/dashboard/src/lib/components/Course/components/Lesson/Exercise/ViewMode.svelte — the summary label needs a translation key added alongside the component change.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/components/Course/components/Lesson/Exercise/ViewMode.svelte | Adds a collapsible details panel showing exercise description during active attempt; HTML is correctly sanitized, but the summary label is hardcoded English rather than using the existing $t() translation function. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Learner opens exercise] --> B{currentQuestionIndex === 0?}
    B -- Yes --> C[Show exercise start screen\nwith full description + Start button]
    C --> D[User clicks Start\ncurrentQuestionIndex = 1]
    D --> E{questionnaire.description truthy?}
    E -- Yes --> F[Render collapsible details panel\nopen=true on Q1, closed on Q2+]
    F --> G[Render current question]
    E -- No --> G
    G --> H{Answer correct?}
    H -- Yes --> I[Increment currentQuestionIndex]
    I --> J{Last question?}
    J -- No --> E
    J -- Yes --> K[Submit exercise\nShow finished view]
```

<sub>Reviews (1): Last reviewed commit: ["fix: keep exercise instructions accessib..."](https://github.com/classroomio/classroomio/commit/202d0d3c65064905f77eea5fe1ab09f0fa7f0a92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31445634)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->