### PR TITLE
Fix public course enrollment links

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -32,7 +32,7 @@ jobs:
         run: pnpm install --no-frozen-lockfile
 
       - name: Build publishable MCP package
-        run: pnpm --filter @classroomio/mcp build
+        run: pnpm mcp:build
 
       - name: Publish package
         if: github.event_name == 'workflow_dispatch'

--- a/apps/dashboard/src/lib/components/CourseLandingPage/components/PricingSection.svelte
+++ b/apps/dashboard/src/lib/components/CourseLandingPage/components/PricingSection.svelte
@@ -27,9 +27,14 @@
   let discount = 0;
   let formatter: Intl.NumberFormat | undefined;
   let isFree = false;
+  let courseOrgSiteName = '';
+  let canJoinCourse = false;
 
   function handleJoinCourse() {
-    if (editMode) return;
+    if (editMode || !canJoinCourse) {
+      startCoursePayment = false;
+      return;
+    }
 
     capturePosthogEvent('join_course', {
       course_id: courseData.id,
@@ -39,7 +44,8 @@
     });
 
     if (isFree) {
-      const link = getStudentInviteLink(courseData, $currentOrg.siteName, $currentOrgDomain);
+      const inviteOrigin = $currentOrgDomain || window.location.origin;
+      const link = getStudentInviteLink(courseData, courseOrgSiteName, inviteOrigin);
 
       goto(link);
     } else {
@@ -61,6 +67,10 @@
   }
 
   $: setFormatter(courseData.currency);
+
+  $: courseOrgSiteName =
+    $currentOrg.siteName || get(courseData, 'group.organization.siteName', '');
+  $: canJoinCourse = !!courseData?.metadata?.allowNewStudent && !!courseOrgSiteName;
 
   $: discount = get(courseData, 'metadata.discount', 0);
   $: calculatedCost = calcCourseDiscount(
@@ -124,7 +134,7 @@
               : $t('course.navItem.landing_page.pricing_section.buy')}
             className="w-full sm:w-full h-[40px]"
             onClick={handleJoinCourse}
-            isDisabled={!courseData.metadata.allowNewStudent}
+            isDisabled={!canJoinCourse}
           />
         </div>
       </div>
@@ -171,7 +181,7 @@
             : $t('course.navItem.landing_page.pricing_section.buy')}
           className="w-full sm:w-full py-3 mb-3"
           onClick={handleJoinCourse}
-          isDisabled={!courseData.metadata.allowNewStudent}
+          isDisabled={!canJoinCourse}
         />
         {#if courseData?.metadata?.showDiscount && courseData.metadata.allowNewStudent}
           <p class="text-sm font-light text-gray-500 dark:text-white">

--- a/apps/dashboard/src/lib/utils/services/courses/index.ts
+++ b/apps/dashboard/src/lib/utils/services/courses/index.ts
@@ -86,6 +86,12 @@ const SLUG_QUERY = `
   version,
   currency,
   metadata,
+  group(
+    id,
+    organization(
+      siteName
+    )
+  ),
   is_certificate_downloadable,
   certificate_theme,
   lesson_section(id, title, order),


### PR DESCRIPTION
## Summary
- include the owning organization site name when loading a public course by slug
- build free-course enrollment links from that course-owned organization metadata instead of relying only on the ambient organization store
- reset the enrollment trigger if the CTA cannot safely build a join link

Fixes #654.

## Validation
- `git diff --check`

Full frontend validation was not run because this environment does not have npm, pnpm, or corepack available.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes broken public-course enrollment links by adding `group(id, organization(siteName))` to the Supabase SLUG query and using the fetched `siteName` to build free-course invite URLs instead of relying solely on the ambient `currentOrg` store.

- **`index.ts`**: Extends `SLUG_QUERY` to include the owning organisation's `siteName`, making it available on `courseData.group.organization.siteName` for public (unauthenticated) page loads.
- **`PricingSection.svelte`**: Introduces `courseOrgSiteName` (with a fallback chain) and `canJoinCourse` (which gates the enroll button); uses these to build the invite link and guard `handleJoinCourse`. The `canJoinCourse` guard now also blocks paid-course enrollment when `courseOrgSiteName` is empty, and `$currentOrg.siteName` takes precedence over the course-owned `siteName`, so a logged-in user from a different org would encode the wrong org name into the invite hash.

<h3>Confidence Score: 3/5</h3>

The free-course invite-link fix is correct, but two defects in PricingSection.svelte should be addressed before merging: paid-course enrollment can be silently broken, and the siteName priority order can wire the wrong org into the invite hash for authenticated cross-org visitors.

The `canJoinCourse` reactive ties the Buy button's enabled state to `courseOrgSiteName`, but paid courses never use `orgSiteName` — they only open a modal. Any org whose `siteName` is empty will have its paid course enrollment silently disabled. Separately, preferring `$currentOrg.siteName` over the course-owned `siteName` means a logged-in cross-org visitor would embed the wrong org name into the invite hash. Both issues affect the core enrollment path.

PricingSection.svelte needs attention for the `canJoinCourse` gating logic and the `courseOrgSiteName` precedence order; `index.ts` is straightforward and correct.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/components/CourseLandingPage/components/PricingSection.svelte | Adds `courseOrgSiteName` / `canJoinCourse` reactives and rewires the free-course invite link; `canJoinCourse` also gates paid-course enrollment unnecessarily, and the siteName precedence order can use the wrong org for cross-org visitors. |
| apps/dashboard/src/lib/utils/services/courses/index.ts | Adds `group(id, organization(siteName))` to the SLUG_QUERY so public course fetches include the owning org's `siteName`; straightforward and correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PricingSection
    participant CourseService
    participant Supabase
    participant OrgStore

    User->>PricingSection: Visit public course landing page
    PricingSection->>CourseService: fetchCourse(slug)
    CourseService->>Supabase: "SELECT ... group(id, organization(siteName)) WHERE slug=..."
    Supabase-->>CourseService: courseData (with group.organization.siteName)
    CourseService-->>PricingSection: courseData

    PricingSection->>OrgStore: $currentOrg.siteName (may be empty for public page)
    PricingSection->>PricingSection: "courseOrgSiteName = $currentOrg.siteName OR courseData.group.organization.siteName"
    PricingSection->>PricingSection: "canJoinCourse = allowNewStudent AND !!courseOrgSiteName"

    User->>PricingSection: Click Enroll (free course)
    alt canJoinCourse is true
        PricingSection->>PricingSection: "inviteOrigin = $currentOrgDomain OR window.location.origin"
        PricingSection->>PricingSection: getStudentInviteLink(courseData, courseOrgSiteName, inviteOrigin)
        PricingSection-->>User: goto(inviteLink)
    else canJoinCourse is false
        PricingSection-->>User: Button disabled
    end

    User->>PricingSection: Click Buy (paid course)
    alt canJoinCourse is true
        PricingSection-->>User: "openModal = true"
    else courseOrgSiteName empty
        PricingSection-->>User: Button disabled (regression)
    end
```

<sub>Reviews (1): Last reviewed commit: ["Fix public course enrollment link"](https://github.com/classroomio/classroomio/commit/e0b5ccc1d58e854ea550c4978481a3c158c1ba67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31451684)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->