### PR TITLE
fix(dashboard): redirect students on app domain to org LMS

### DIFF
--- a/apps/dashboard/src/lib/features/app/init.svelte.ts
+++ b/apps/dashboard/src/lib/features/app/init.svelte.ts
@@ -1,6 +1,5 @@
 import { BaseApi, classroomio } from '$lib/utils/services/api';
-import { getOrgSiteUrl } from '$lib/utils/functions/org';
-import { currentOrg, mergeAccountOrgFromServer, orgs } from '$lib/utils/store/org';
+import { currentOrg, getOrgPublicUrl, mergeAccountOrgFromServer, orgs } from '$lib/utils/store/org';
 import { defaultProfileState, defaultUserState, profile, user } from '$lib/utils/store/user';
 
 import type { AccountResponse } from './types';
@@ -218,7 +217,7 @@ class AppInitApi extends BaseApi {
     const selectedOrg = get(currentOrg);
 
     if (isCloud && !isOrgSite && isStudent && selectedOrg.siteName) {
-      window.location.href = getOrgSiteUrl(selectedOrg, '/lms');
+      window.location.href = getOrgPublicUrl(selectedOrg, '/lms');
       return;
     }
 

--- a/apps/dashboard/src/lib/features/app/init.svelte.ts
+++ b/apps/dashboard/src/lib/features/app/init.svelte.ts
@@ -1,4 +1,5 @@
 import { BaseApi, classroomio } from '$lib/utils/services/api';
+import { getOrgSiteUrl } from '$lib/utils/functions/org';
 import { currentOrg, mergeAccountOrgFromServer, orgs } from '$lib/utils/store/org';
 import { defaultProfileState, defaultUserState, profile, user } from '$lib/utils/store/user';
 
@@ -201,12 +202,26 @@ class AppInitApi extends BaseApi {
 
     if (!shouldRedirectOnAuth(page.url.pathname)) return;
 
+    // Students with existing org memberships who open /onboarding may intend to create their own academy.
+    if (path.includes('/onboarding') && isStudent && userHasOrganizations) {
+      return;
+    }
+
     const shouldGoToLMS = isCloud ? isOrgSite || !!isStudent : !!isStudent;
     console.log('redirecting to', shouldGoToLMS ? 'lms' : 'org');
-    return shouldGoToLMS ? this.goToLMS() : this.goToOrg();
+    return shouldGoToLMS ? this.goToLMS(isOrgSite) : this.goToOrg();
   }
 
-  goToLMS() {
+  goToLMS(isOrgSite: boolean) {
+    const isCloud = PUBLIC_IS_SELFHOSTED !== 'true';
+    const isStudent = get(isOrgStudent);
+    const selectedOrg = get(currentOrg);
+
+    if (isCloud && !isOrgSite && isStudent && selectedOrg.siteName) {
+      window.location.href = getOrgSiteUrl(selectedOrg, '/lms');
+      return;
+    }
+
     goto(resolve('/lms', {}));
   }
 

--- a/apps/dashboard/src/lib/utils/functions/org.ts
+++ b/apps/dashboard/src/lib/utils/functions/org.ts
@@ -1,5 +1,33 @@
+import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
+import type { AccountOrg } from '$features/app/types';
+import { TENANT_ROOT_DOMAIN } from '@cio/utils/constants';
+
+export function getOrgSiteUrl(
+  org: Pick<AccountOrg, 'siteName' | 'customDomain' | 'isCustomDomainVerified'>,
+  pathname = '/'
+): string {
+  let origin: string;
+
+  if (browser && window.location.host.includes('localhost')) {
+    origin = window.location.origin;
+  } else if (org.customDomain && org.isCustomDomainVerified) {
+    origin = `https://${org.customDomain}`;
+  } else if (org.siteName) {
+    origin = `https://${org.siteName}.${TENANT_ROOT_DOMAIN}`;
+  } else {
+    return pathname;
+  }
+
+  const url = new URL(pathname, origin);
+
+  if (browser && window.location.host.includes('localhost') && org.siteName) {
+    url.searchParams.set('org', org.siteName);
+  }
+
+  return url.toString();
+}
 
 export function genQuizPin(): number {
   const minm = 100000;

--- a/apps/dashboard/src/lib/utils/functions/org.ts
+++ b/apps/dashboard/src/lib/utils/functions/org.ts
@@ -1,33 +1,5 @@
-import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
-import type { AccountOrg } from '$features/app/types';
-import { TENANT_ROOT_DOMAIN } from '@cio/utils/constants';
-
-export function getOrgSiteUrl(
-  org: Pick<AccountOrg, 'siteName' | 'customDomain' | 'isCustomDomainVerified'>,
-  pathname = '/'
-): string {
-  let origin: string;
-
-  if (browser && window.location.host.includes('localhost')) {
-    origin = window.location.origin;
-  } else if (org.customDomain && org.isCustomDomainVerified) {
-    origin = `https://${org.customDomain}`;
-  } else if (org.siteName) {
-    origin = `https://${org.siteName}.${TENANT_ROOT_DOMAIN}`;
-  } else {
-    return pathname;
-  }
-
-  const url = new URL(pathname, origin);
-
-  if (browser && window.location.host.includes('localhost') && org.siteName) {
-    url.searchParams.set('org', org.siteName);
-  }
-
-  return url.toString();
-}
 
 export function genQuizPin(): number {
   const minm = 100000;

--- a/apps/dashboard/src/lib/utils/store/org.ts
+++ b/apps/dashboard/src/lib/utils/store/org.ts
@@ -104,6 +104,26 @@ export function getOrgPublicOrigin(org: OrgPublicOrigin): string {
   return browser ? window.location.origin : '';
 }
 
+/** Absolute URL on an org's public tenant site (e.g. `/lms`, `/course/{slug}`). Client-only. */
+export function getOrgPublicUrl(org: OrgPublicOrigin, pathname = '/'): string {
+  if (!browser) {
+    return pathname;
+  }
+
+  const origin = getOrgPublicOrigin(org);
+  if (!origin) {
+    return pathname;
+  }
+
+  const url = new URL(pathname, origin);
+
+  if (window.location.host.includes('localhost') && org.siteName) {
+    url.searchParams.set('org', org.siteName);
+  }
+
+  return url.toString();
+}
+
 export const currentOrgDomain = derived(currentOrg, ($currentOrg) => getOrgPublicOrigin($currentOrg));
 
 export const isFreePlan = derived(currentOrg, ($currentOrg) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Students who log in on `app.classroomio.com` were redirected to `/lms` on the app host instead of their org's tenant domain. This change sends them to `{org}.myclassroomio.com/lms` (or the org's verified custom domain) via a full page reload.

## Behavior

| Context | Before | After |
|---------|--------|-------|
| Org site (`*.myclassroomio.com` / custom domain) | `/lms` on same domain | unchanged |
| `app.classroomio.com` + student role | `/lms` on app host | full reload to org domain + `/lms` |
| Self-hosted | `/lms` on same domain | unchanged |
| Student on `/onboarding` with existing org | redirected away to LMS | stays on onboarding (academy creation) |

## Implementation

- Added `getOrgSiteUrl()` in `apps/dashboard/src/lib/utils/functions/org.ts` to build tenant URLs (subdomain, custom domain, or localhost `?org=` dev param).
- Updated `goToLMS()` in `apps/dashboard/src/lib/features/app/init.svelte.ts` to cross-domain redirect when cloud + not org site + student.
- Added an onboarding exception so students who intentionally open `/onboarding` to create their own academy are not bounced to their school's LMS.

## Edge case note

The onboarding exception is a minimal first step for users who belong to an org as a student but want to create their own academy with the same email. A fuller product decision may still be needed (e.g. explicit "Create academy" entry point vs. auto-redirect heuristics).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2976ad3b-32cb-4a5e-abe5-0cc70fec1843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2976ad3b-32cb-4a5e-abe5-0cc70fec1843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes students on `app.classroomio.com` being routed to `/lms` on the wrong (app) domain instead of their org's tenant domain. It adds a `getOrgPublicUrl()` helper to construct the correct tenant URL and updates `goToLMS()` to do a full-page cross-domain redirect when on the app domain as a student.

- `getOrgPublicUrl()` in `org.ts` correctly resolves custom domains, subdomain tenants (`{org}.myclassroomio.com`), and localhost dev via an `?org=` query param.
- `goToLMS(isOrgSite)` now triggers `window.location.href` for the cross-domain case; org-site students still use the existing same-domain `goto('/lms')` path, so no redirect loop is possible.
- A new onboarding exception lets students who already belong to an org stay on `/onboarding` to create their own academy \u2014 but the guard is missing an `!isOrgSite` check, meaning it also silently suppresses the LMS redirect when a student lands on `/onboarding` on an org tenant site.

<h3>Confidence Score: 3/5</h3>

The cross-domain redirect logic is sound, but the onboarding exception in init.svelte.ts is missing a scope guard and could leave students stranded on a tenant site path that may not exist.

The new getOrgPublicUrl helper and goToLMS cross-domain redirect are well-constructed and handle all the documented cases correctly. The onboarding exception does not restrict itself to the app domain — a student visiting /onboarding on an org tenant site will also skip the LMS redirect, potentially landing on an invalid route in tenant context. The fix is a one-line addition.

apps/dashboard/src/lib/features/app/init.svelte.ts — the onboarding exception needs an !isOrgSite guard and a tighter path match.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/app/init.svelte.ts | Adds onboarding exception and cross-domain LMS redirect for students on app domain. The onboarding exception is missing a !isOrgSite guard, meaning it unintentionally also fires on org tenant sites. String includes() match is also overly broad. |
| apps/dashboard/src/lib/utils/store/org.ts | Adds getOrgPublicUrl() helper that builds an absolute tenant URL with correct handling for custom domains, subdomain tenants, and localhost dev (via ?org= param). Logic is clean and the !browser SSR guard is correct. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Student
    participant AppDomain as app.classroomio.com
    participant OrgSite as {org}.myclassroomio.com/lms

    Student->>AppDomain: Login / navigate to /login or /onboarding
    AppDomain->>AppDomain: setupApp() to routeUserToNextPage()
    AppDomain->>AppDomain: "isOrgSite=false, isStudent=true, isCloud=true"

    alt path includes /onboarding AND isStudent AND userHasOrgs
        AppDomain-->>Student: Stay on /onboarding (new exception)
    else normal student redirect
        AppDomain->>AppDomain: "shouldGoToLMS=true then goToLMS(isOrgSite=false)"
        AppDomain->>AppDomain: isCloud AND NOT isOrgSite AND isStudent AND siteName
        AppDomain-->>Student: "window.location.href = getOrgPublicUrl(org, '/lms')"
        Student->>OrgSite: Full page reload to org tenant LMS
    end

    Note over OrgSite: isOrgSite=true, goToLMS(true) uses goto('/lms') locally, no loop
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Student
    participant AppDomain as app.classroomio.com
    participant OrgSite as {org}.myclassroomio.com/lms

    Student->>AppDomain: Login / navigate to /login or /onboarding
    AppDomain->>AppDomain: setupApp() to routeUserToNextPage()
    AppDomain->>AppDomain: "isOrgSite=false, isStudent=true, isCloud=true"

    alt path includes /onboarding AND isStudent AND userHasOrgs
        AppDomain-->>Student: Stay on /onboarding (new exception)
    else normal student redirect
        AppDomain->>AppDomain: "shouldGoToLMS=true then goToLMS(isOrgSite=false)"
        AppDomain->>AppDomain: isCloud AND NOT isOrgSite AND isStudent AND siteName
        AppDomain-->>Student: "window.location.href = getOrgPublicUrl(org, '/lms')"
        Student->>OrgSite: Full page reload to org tenant LMS
    end

    Note over OrgSite: isOrgSite=true, goToLMS(true) uses goto('/lms') locally, no loop
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor(dashboard): use getOrgPublicUrl..."](https://github.com/classroomio/classroomio/commit/7c12042c683072d24f93be28736cad82541fadc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38907805)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->