### PR TITLE
fix(dashboard): use verified custom domain for view-as-student handoff

### DIFF
--- a/apps/dashboard/src/lib/features/course/utils/course-preview.ts
+++ b/apps/dashboard/src/lib/features/course/utils/course-preview.ts
@@ -1,7 +1,9 @@
+import { get } from 'svelte/store';
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
 import { snackbar } from '$features/ui/snackbar/store';
 import { accountApi } from '$features/account/api/account.svelte';
+import { currentOrg, getOrgPublicOrigin } from '$lib/utils/store/org';
 
 interface OpenCoursePreviewOptions {
   courseId: string;
@@ -21,7 +23,7 @@ export function getPublicCoursePageUrl(courseSlug: string, currentOrgDomain = ''
   }
 
   const trimmedDomain = currentOrgDomain?.trim();
-  const origin = trimmedDomain || window.location.origin;
+  const origin = trimmedDomain || getOrgPublicOrigin(get(currentOrg));
 
   return new URL(resolve(`/course/${courseSlug}`, {}), origin).toString();
 }
@@ -73,7 +75,7 @@ export async function viewAsStudent({ courseId, currentOrgDomain = '' }: ViewAsS
     return false;
   }
 
-  const origin = currentOrgDomain?.trim() || window.location.origin;
+  const origin = currentOrgDomain?.trim() || getOrgPublicOrigin(get(currentOrg));
   const loginLinkUrl = new URL('/api/auth/login-link', origin);
   loginLinkUrl.searchParams.set('token', token);
   loginLinkUrl.searchParams.set('redirect', `/courses/${courseId}/lessons?next=true`);

--- a/apps/dashboard/src/lib/utils/store/org.ts
+++ b/apps/dashboard/src/lib/utils/store/org.ts
@@ -81,16 +81,16 @@ type OrgPublicOrigin = Pick<AccountOrg, 'customDomain' | 'isCustomDomainVerified
 
 /**
  * Public origin for an org's tenant site (student LMS, public course pages, login-link handoff).
- * Verified custom domains win over the current browser host so admin URLs like
- * `app.example.com` still hand off to `example.com`.
+ * Self-hosted uses the current deployment URL. On cloud, verified custom domains win over the
+ * admin host so `app.classroomio.com` still hands off to the org's `example.com` tenant site.
  */
 export function getOrgPublicOrigin(org: OrgPublicOrigin): string {
-  if (org.customDomain && org.isCustomDomainVerified) {
-    return `https://${org.customDomain}`;
-  }
-
   if (PUBLIC_IS_SELFHOSTED === 'true') {
     return browser ? window.location.origin : '';
+  }
+
+  if (org.customDomain && org.isCustomDomainVerified) {
+    return `https://${org.customDomain}`;
   }
 
   if (dev && browser) {

--- a/apps/dashboard/src/lib/utils/store/org.ts
+++ b/apps/dashboard/src/lib/utils/store/org.ts
@@ -77,19 +77,34 @@ export const currentOrgPath = derived(currentOrg, ($currentOrg) =>
   $currentOrg.siteName ? `/org/${$currentOrg.siteName}` : '#'
 );
 
-export const currentOrgDomain = derived(currentOrg, ($currentOrg) => {
-  if (PUBLIC_IS_SELFHOSTED === 'true') return window.location.origin;
+type OrgPublicOrigin = Pick<AccountOrg, 'customDomain' | 'isCustomDomainVerified' | 'siteName'>;
 
-  const browserOrigin = dev && browser && window.location.origin;
+/**
+ * Public origin for an org's tenant site (student LMS, public course pages, login-link handoff).
+ * Verified custom domains win over the current browser host so admin URLs like
+ * `app.example.com` still hand off to `example.com`.
+ */
+export function getOrgPublicOrigin(org: OrgPublicOrigin): string {
+  if (org.customDomain && org.isCustomDomainVerified) {
+    return `https://${org.customDomain}`;
+  }
 
-  return browserOrigin
-    ? browserOrigin
-    : $currentOrg.customDomain && $currentOrg.isCustomDomainVerified
-      ? `https://${$currentOrg.customDomain}`
-      : $currentOrg.siteName
-        ? `https://${$currentOrg.siteName}.${TENANT_ROOT_DOMAIN}`
-        : '';
-});
+  if (PUBLIC_IS_SELFHOSTED === 'true') {
+    return browser ? window.location.origin : '';
+  }
+
+  if (dev && browser) {
+    return window.location.origin;
+  }
+
+  if (org.siteName) {
+    return `https://${org.siteName}.${TENANT_ROOT_DOMAIN}`;
+  }
+
+  return browser ? window.location.origin : '';
+}
+
+export const currentOrgDomain = derived(currentOrg, ($currentOrg) => getOrgPublicOrigin($currentOrg));
 
 export const isFreePlan = derived(currentOrg, ($currentOrg) => {
   if (!$currentOrg.id || PUBLIC_IS_SELFHOSTED === 'true') return false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

"View as student" was sending cloud users to the wrong host when an org has a verified custom domain.

## Root cause (cloud only)

On cloud, `currentOrgDomain` could fall back to `window.location.origin` before using the org's verified custom domain. Teachers managing courses from `app.classroomio.com` need the handoff to go to `customdomain.com`, not the admin host.

Self-hosted is different: admin and LMS share one deployment URL, so it should always use `window.location.origin`.

## Fix

- Extract `getOrgPublicOrigin()` with explicit resolution order:
  1. **Self-hosted** → `window.location.origin` (always)
  2. **Cloud + verified custom domain** → `https://{customDomain}`
  3. **Cloud dev** → `window.location.origin`
  4. **Cloud + siteName** → `https://{siteName}.myclassroomio.com`
- Use it for `currentOrgDomain` and as the fallback in `viewAsStudent` / `getPublicCoursePageUrl`

## Test plan

- [ ] Cloud org with verified custom domain `example.com`, admin on `app.classroomio.com` → handoff opens `https://example.com/api/auth/login-link?...`
- [ ] Self-hosted on `https://lms.example.com` → handoff stays on `https://lms.example.com`
- [ ] Cloud org without custom domain → `{siteName}.myclassroomio.com`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbf4c222-7e1c-429f-91ad-3469d31e804e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbf4c222-7e1c-429f-91ad-3469d31e804e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the "View as student" handoff for cloud orgs with verified custom domains by introducing `getOrgPublicOrigin()` — a pure function that correctly resolves the tenant's public origin based on deployment mode and domain configuration. The `window.location.origin` fallback inside `viewAsStudent` and `getPublicCoursePageUrl` is replaced with a call to this function, ensuring teachers on `app.classroomio.com` are handed off to `https://customdomain.com` rather than the admin host.

- `getOrgPublicOrigin()` is extracted from the `currentOrgDomain` derived store and exported so `course-preview.ts` can call it directly (via `get(currentOrg)`) when no explicit domain prop is supplied by the caller.
- SSR safety is improved: the old self-hosted branch called `window.location.origin` unconditionally; the new function guards it with `browser`.
- One ordering concern: the custom-domain check now runs before the `dev && browser` branch, meaning local dev environments with a verified custom domain configured on the org will be redirected to the live tenant host rather than `localhost` — the opposite of what the PR description describes for the \"Cloud dev\" case.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the production cloud case it targets; only a dev-mode ordering question remains.

The core fix is correct and well-scoped: the custom-domain check now wins over the old window.location.origin fallback for cloud orgs. The SSR guard added to the self-hosted path is a genuine improvement. The only open question is whether dev && browser should short-circuit before or after the custom-domain check — the PR description says dev should always use window.location.origin, but the implementation evaluates the custom domain first. This only affects developer machines, not production users.

apps/dashboard/src/lib/utils/store/org.ts — specifically the ordering of the dev && browser branch relative to the custom-domain check.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/utils/store/org.ts | Extracts getOrgPublicOrigin() pure function from currentOrgDomain derived store; correctly prioritises verified custom domain over dev-mode window.location.origin, adds SSR safety guard for self-hosted path, and removes the previous fallthrough that let window.location.origin win on cloud. |
| apps/dashboard/src/lib/features/course/utils/course-preview.ts | Replaces bare window.location.origin fallback in getPublicCoursePageUrl and viewAsStudent with getOrgPublicOrigin(get(currentOrg)); imports currentOrg store and get to snapshot it at call time so the correct tenant origin is used when callers omit currentOrgDomain. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["viewAsStudent / getPublicCoursePageUrl called"] --> B{currentOrgDomain\nprop provided?}
    B -- "yes (non-empty)" --> C["use prop value as origin"]
    B -- "no / empty" --> D["getOrgPublicOrigin(get(currentOrg))"]

    D --> E{PUBLIC_IS_SELFHOSTED\n=== 'true'?}
    E -- yes --> F["window.location.origin\n(deployment host)"]
    E -- no --> G{customDomain &&\nisCustomDomainVerified?}
    G -- yes --> H["https://customDomain"]
    G -- no --> I{dev && browser?}
    I -- yes --> J["window.location.origin\n(localhost in dev)"]
    I -- no --> K{siteName\npresent?}
    K -- yes --> L["https://siteName.myclassroomio.com"]
    K -- no --> M["window.location.origin\n(fallback)"]

    C --> N["Build URL with origin"]
    F --> N
    H --> N
    J --> N
    L --> N
    M --> N
    N --> O["open / return URL"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["viewAsStudent / getPublicCoursePageUrl called"] --> B{currentOrgDomain\nprop provided?}
    B -- "yes (non-empty)" --> C["use prop value as origin"]
    B -- "no / empty" --> D["getOrgPublicOrigin(get(currentOrg))"]

    D --> E{PUBLIC_IS_SELFHOSTED\n=== 'true'?}
    E -- yes --> F["window.location.origin\n(deployment host)"]
    E -- no --> G{customDomain &&\nisCustomDomainVerified?}
    G -- yes --> H["https://customDomain"]
    G -- no --> I{dev && browser?}
    I -- yes --> J["window.location.origin\n(localhost in dev)"]
    I -- no --> K{siteName\npresent?}
    K -- yes --> L["https://siteName.myclassroomio.com"]
    K -- no --> M["window.location.origin\n(fallback)"]

    C --> N["Build URL with origin"]
    F --> N
    H --> N
    J --> N
    L --> N
    M --> N
    N --> O["open / return URL"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): keep self-hosted org ori..."](https://github.com/classroomio/classroomio/commit/4d1e1296f601fb9a51717e0bea52800ce210d523) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38657629)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->