### PR TITLE
fix(dashboard): course menu icons, delete scroll, and settings tags auth

### DIFF
--- a/apps/api/src/routes/organization/tags.ts
+++ b/apps/api/src/routes/organization/tags.ts
@@ -23,6 +23,7 @@ import { authMiddleware } from '@api/middlewares/auth';
 import { authOrAutomationKeyMiddleware } from '@api/middlewares/auth-or-automation-key';
 import { handleError } from '@api/utils/errors';
 import { orgAdminMiddleware } from '@api/middlewares/org-admin';
+import { orgMemberMiddleware } from '@api/middlewares/org-member';
 import { orgAdminOrAutomationKeyMiddleware } from '@api/middlewares/org-admin-or-automation-key';
 import { assertMcpAutomationUsageAllowed, recordMcpAutomationUsage } from '@api/services/organization/automation-usage';
 import { zValidator } from '@hono/zod-validator';
@@ -44,7 +45,7 @@ export const tagsRouter = new Hono()
       return handleError(c, error, 'Failed to fetch public tags');
     }
   })
-  .get('/', authMiddleware, orgAdminMiddleware, async (c) => {
+  .get('/', authMiddleware, orgMemberMiddleware, async (c) => {
     try {
       const orgId = c.req.header('cio-org-id')!;
       const groups = await getOrganizationTagGroups(orgId);

--- a/apps/dashboard/src/lib/features/course/components/course-context-menu-content.svelte
+++ b/apps/dashboard/src/lib/features/course/components/course-context-menu-content.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import * as DropdownMenu from '@cio/ui/base/dropdown-menu';
-  import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
-  import CopyIcon from '@lucide/svelte/icons/copy';
-  import EyeIcon from '@lucide/svelte/icons/eye';
+  import { page } from '$app/state';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { copyCourseModal, deleteCourseModal } from '$features/course/utils/store';
@@ -43,12 +41,22 @@
   }: Props = $props();
 
   const showPublicCourseLinks = $derived(isPublished && courseType === 'PUBLIC' && slug.trim().length > 0);
+  const courseSettingsPath = $derived(resolve(`/courses/${id}/settings`, {}));
 
   function redirect(url: string) {
     goto(resolve(url, {}));
   }
 
+  function scrollToSettingsSection(sectionId: string) {
+    document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
   function handleShareCourse() {
+    if (page.url.pathname === courseSettingsPath) {
+      scrollToSettingsSection('share');
+      return;
+    }
+
     redirect(`/courses/${id}/settings#share`);
   }
 
@@ -57,13 +65,29 @@
   }
 
   function handlePublishCourse() {
+    if (page.url.pathname === courseSettingsPath) {
+      scrollToSettingsSection('publish');
+      return;
+    }
+
     redirect(`/courses/${id}/settings#publish`);
   }
 
   function handleDeleteCourse() {
-    $deleteCourseModal.open = true;
-    $deleteCourseModal.id = id;
-    $deleteCourseModal.title = title;
+    if (page.url.pathname === courseSettingsPath) {
+      scrollToSettingsSection('delete');
+      return;
+    }
+
+    const isOnOrgCoursesList = /\/org\/[^/]+\/courses\/?$/.test(page.url.pathname);
+    if (isOnOrgCoursesList) {
+      $deleteCourseModal.open = true;
+      $deleteCourseModal.id = id;
+      $deleteCourseModal.title = title;
+      return;
+    }
+
+    redirect(`/courses/${id}/settings#delete`);
   }
 
   function handleCloneCourse() {
@@ -92,17 +116,14 @@
 
 {#if lmsPublicQuickOnly}
   <DropdownMenu.Item onclick={handleViewCourseSite}>
-    <ExternalLinkIcon size={16} class="mr-2" />
     {$t('courses.course_card.context_menu.view_course_site')}
   </DropdownMenu.Item>
   <DropdownMenu.Item onclick={() => void handleCopyCourseUrl()}>
-    <CopyIcon size={16} class="mr-2" />
     {$t('courses.course_card.context_menu.copy_course_url')}
   </DropdownMenu.Item>
 {:else}
   {#if includeViewAsStudent}
     <DropdownMenu.Item onclick={() => onViewAsStudent?.()}>
-      <EyeIcon size={16} class="mr-2" />
       {$t('course.header.view_as_student')}
     </DropdownMenu.Item>
     <DropdownMenu.Separator />
@@ -110,12 +131,10 @@
 
   {#if isPublished}
     <DropdownMenu.Item onclick={handleViewCourseSite}>
-      <ExternalLinkIcon size={16} class="mr-2" />
       {$t('courses.course_card.context_menu.view_course_site')}
     </DropdownMenu.Item>
     {#if showPublicCourseLinks}
       <DropdownMenu.Item onclick={() => void handleCopyCourseUrl()}>
-        <CopyIcon size={16} class="mr-2" />
         {$t('courses.course_card.context_menu.copy_course_url')}
       </DropdownMenu.Item>
     {/if}

--- a/apps/dashboard/src/lib/features/course/pages/settings.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/settings.svelte
@@ -34,8 +34,7 @@
   import { uploadImage } from '$lib/utils/services/upload';
   import { copyToClipboard } from '$lib/utils/functions/formatYoutubeVideo';
   import { handleOpenWidget } from '$features/ui/course-landing-page/store';
-  import { currentOrgDomain, currentOrgPath, isFreePlan, isOrgAdmin } from '$lib/utils/store/org';
-  import { get } from 'svelte/store';
+  import { currentOrgDomain, currentOrgPath, isFreePlan } from '$lib/utils/store/org';
   import { page } from '$app/stores';
 
   interface Props {
@@ -60,8 +59,6 @@
   let loadedCourseTagsForId = $state<string | null>(null);
   let isTagPopoverOpen = $state(false);
 
-  const canManageCourseTags = $derived($isOrgAdmin === true);
-
   function normalizeTagIds(tagIds: string[]) {
     return Array.from(new Set(tagIds));
   }
@@ -80,13 +77,7 @@
   async function loadCourseTags(courseId: string) {
     loadedCourseTagsForId = courseId;
 
-    const requests: Promise<unknown>[] = [tagApi.getCourseTags(courseId)];
-
-    if (get(isOrgAdmin) === true) {
-      requests.unshift(tagApi.getTagGroups());
-    }
-
-    await Promise.all(requests);
+    await Promise.all([tagApi.getTagGroups(), tagApi.getCourseTags(courseId)]);
 
     const assignedTagIds = normalizeTagIds(tagApi.courseTags.map((tag) => tag.id));
     selectedTagIds = assignedTagIds;
@@ -187,7 +178,7 @@
       };
 
       const normalizedSelectedTagIds = normalizeTagIds(selectedTagIds);
-      const hasTagChanges = get(isOrgAdmin) === true && !areSameTagIds(normalizedSelectedTagIds, initialTagIds);
+      const hasTagChanges = !areSameTagIds(normalizedSelectedTagIds, initialTagIds);
 
       const updatePayload = {
         ...updatedCourse,
@@ -560,29 +551,25 @@
                   aria-hidden="true"
                 ></span>
                 <span>{tag.name}</span>
-                {#if canManageCourseTags}
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    class="h-5 w-5"
-                    onclick={() => removeSelectedTag(tag.id)}
-                  >
-                    <XIcon />
-                  </Button>
-                {/if}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  class="h-5 w-5"
+                  onclick={() => removeSelectedTag(tag.id)}
+                >
+                  <XIcon />
+                </Button>
               </Badge>
             {/each}
           {/if}
 
-          {#if canManageCourseTags}
-            <CourseTagPicker
-              tagGroups={tagApi.tagGroups}
-              {selectedTagIds}
-              bind:open={isTagPopoverOpen}
-              onTagToggle={toggleTagSelection}
-            />
-          {/if}
+          <CourseTagPicker
+            tagGroups={tagApi.tagGroups}
+            {selectedTagIds}
+            bind:open={isTagPopoverOpen}
+            onTagToggle={toggleTagSelection}
+          />
         </div>
       </div>
     </Field.Field>

--- a/apps/dashboard/src/lib/features/course/pages/settings.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/settings.svelte
@@ -34,7 +34,8 @@
   import { uploadImage } from '$lib/utils/services/upload';
   import { copyToClipboard } from '$lib/utils/functions/formatYoutubeVideo';
   import { handleOpenWidget } from '$features/ui/course-landing-page/store';
-  import { currentOrgDomain, currentOrgPath, isFreePlan } from '$lib/utils/store/org';
+  import { currentOrgDomain, currentOrgPath, isFreePlan, isOrgAdmin } from '$lib/utils/store/org';
+  import { get } from 'svelte/store';
   import { page } from '$app/stores';
 
   interface Props {
@@ -59,6 +60,8 @@
   let loadedCourseTagsForId = $state<string | null>(null);
   let isTagPopoverOpen = $state(false);
 
+  const canManageCourseTags = $derived($isOrgAdmin === true);
+
   function normalizeTagIds(tagIds: string[]) {
     return Array.from(new Set(tagIds));
   }
@@ -77,7 +80,13 @@
   async function loadCourseTags(courseId: string) {
     loadedCourseTagsForId = courseId;
 
-    await Promise.all([tagApi.getTagGroups(), tagApi.getCourseTags(courseId)]);
+    const requests: Promise<unknown>[] = [tagApi.getCourseTags(courseId)];
+
+    if (get(isOrgAdmin) === true) {
+      requests.unshift(tagApi.getTagGroups());
+    }
+
+    await Promise.all(requests);
 
     const assignedTagIds = normalizeTagIds(tagApi.courseTags.map((tag) => tag.id));
     selectedTagIds = assignedTagIds;
@@ -178,7 +187,7 @@
       };
 
       const normalizedSelectedTagIds = normalizeTagIds(selectedTagIds);
-      const hasTagChanges = !areSameTagIds(normalizedSelectedTagIds, initialTagIds);
+      const hasTagChanges = get(isOrgAdmin) === true && !areSameTagIds(normalizedSelectedTagIds, initialTagIds);
 
       const updatePayload = {
         ...updatedCourse,
@@ -305,6 +314,17 @@
     }
 
     loadCourseTags(courseId);
+  });
+
+  $effect(() => {
+    const sectionId = $page.url.hash.replace('#', '').trim();
+    if (!sectionId) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
   });
 
   const selectedTagChips = $derived.by(() => {
@@ -540,25 +560,29 @@
                   aria-hidden="true"
                 ></span>
                 <span>{tag.name}</span>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  class="h-5 w-5"
-                  onclick={() => removeSelectedTag(tag.id)}
-                >
-                  <XIcon />
-                </Button>
+                {#if canManageCourseTags}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    class="h-5 w-5"
+                    onclick={() => removeSelectedTag(tag.id)}
+                  >
+                    <XIcon />
+                  </Button>
+                {/if}
               </Badge>
             {/each}
           {/if}
 
-          <CourseTagPicker
-            tagGroups={tagApi.tagGroups}
-            {selectedTagIds}
-            bind:open={isTagPopoverOpen}
-            onTagToggle={toggleTagSelection}
-          />
+          {#if canManageCourseTags}
+            <CourseTagPicker
+              tagGroups={tagApi.tagGroups}
+              {selectedTagIds}
+              bind:open={isTagPopoverOpen}
+              onTagToggle={toggleTagSelection}
+            />
+          {/if}
         </div>
       </div>
     </Field.Field>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes post-merge issues with the course site menu work.

### 1. Inconsistent dropdown icons
Removed all icons from `course-context-menu-content.svelte` so menu items are text-only.

### 2. Delete does nothing on settings page
`Delete` previously opened `deleteCourseModal`, which only exists on the org courses list page. Now:
- **On settings page** → scrolls to the `#delete` section
- **On org courses list** → opens the delete modal (unchanged)
- **Elsewhere in a course** → navigates to `/courses/{id}/settings#delete`

Share and Publish course behave the same when already on settings (scroll instead of no-op).

### 3. `ORG_TEAM_NOT_AUTHORIZED` on settings load
**Root cause:** `GET /organization/tags` was restricted to org admins only.

**Fix:** Changed the route to use `orgMemberMiddleware` so any org member can fetch tags. Reverted the dashboard workaround that skipped tag group fetches for non-admins. Create/update/delete tag endpoints remain admin-only.

## Test plan
- [ ] Header 3-dot menu: no icons on any items
- [ ] On course settings, click Delete in header menu → scrolls to delete section
- [ ] On course settings as non-admin org member (tutor/student) → `GET /organization/tags` succeeds
- [ ] On course settings as org admin → tag picker still works
- [ ] Tag admin pages still require org admin for writes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07a09f79-73da-457f-8cff-6d9b1a72218b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07a09f79-73da-457f-8cff-6d9b1a72218b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three post-merge regressions: dropdown menu icons are removed for a text-only appearance, the Delete action in the course header menu is now context-aware (scrolls on settings page, opens modal on org courses list, or navigates elsewhere), and `GET /organization/tags` is opened to all org members to fix an `ORG_TEAM_NOT_AUTHORIZED` error for non-admins.

- **API auth fix** (`tags.ts`): `GET /` downgraded from `orgAdminMiddleware` to `orgMemberMiddleware`; all mutating endpoints remain admin-only.
- **Context-aware routing** (`course-context-menu-content.svelte`): Delete/Share/Publish now scroll in-place when already on the settings page, or navigate with a hash fragment otherwise.
- **Hash-scroll effect** (`settings.svelte`): New `$effect` scrolls to the section identified by the URL hash on navigation; uses a legacy `$app/stores` import that causes the effect to re-subscribe to the full `$page` store.

<h3>Confidence Score: 4/5</h3>

The API and menu-routing changes are solid; the hash-scroll effect in settings.svelte can silently scroll the page back to a section whenever the URL updates while the hash is still present.

The new $effect in settings.svelte subscribes to the full Svelte 4 $page store. Because the hash is never cleared after the initial scroll, any subsequent URL change on the settings page re-runs the effect and jumps the user back to the target section. The two other changes — the API middleware downgrade and the context-aware Delete routing — are straightforward and correct.

apps/dashboard/src/lib/features/course/pages/settings.svelte — the new hash-scroll $effect and the legacy $app/stores import.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/organization/tags.ts | GET / downgraded from orgAdminMiddleware to orgMemberMiddleware; all write endpoints remain admin-only. Correct fix for the ORG_TEAM_NOT_AUTHORIZED regression. |
| apps/dashboard/src/lib/features/course/components/course-context-menu-content.svelte | Removes menu icons; improves handleDeleteCourse with context-aware routing (scroll on settings page, open modal on org courses list, navigate otherwise). Logic and regex look correct. |
| apps/dashboard/src/lib/features/course/pages/settings.svelte | New $effect for hash-based scrolling can re-trigger on any $page store update while the hash remains in the URL, causing unexpected scroll-jacking. Also still imports from legacy $app/stores rather than $app/state. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Delete in header menu] --> B{On settings page?}
    B -->|Yes| C[scrollToSettingsSection 'delete']
    B -->|No| D{On org courses list?}
    D -->|Yes| E[Open deleteCourseModal]
    D -->|No| F[goto /courses/id/settings#delete]
    F --> G[settings.svelte mounts / hash changes]
    G --> H["$effect reads $page.url.hash"]
    H --> I[requestAnimationFrame → scrollIntoView]
    I --> J[Hash remains in URL]
    J -->|Any $page store update| H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User clicks Delete in header menu] --> B{On settings page?}
    B -->|Yes| C[scrollToSettingsSection 'delete']
    B -->|No| D{On org courses list?}
    D -->|Yes| E[Open deleteCourseModal]
    D -->|No| F[goto /courses/id/settings#delete]
    F --> G[settings.svelte mounts / hash changes]
    G --> H["$effect reads $page.url.hash"]
    H --> I[requestAnimationFrame → scrollIntoView]
    I --> J[Hash remains in URL]
    J -->|Any $page store update| H
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dashboard/src/lib/features/course/pages/settings.svelte`, line 38 ([link](https://github.com/classroomio/classroomio/blob/c1d023d6e561c2d2b13014c53441d7dbc8f6d323/apps/dashboard/src/lib/features/course/pages/settings.svelte#L38)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `settings.svelte` still imports `page` from the legacy `$app/stores` API, while the newly-modified `course-context-menu-content.svelte` already uses the Svelte 5 `$app/state` import. Switching to `$app/state` in settings removes the Svelte 4 store subscription overhead and keeps the two files consistent.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(api): allow org members to fetch org..."](https://github.com/classroomio/classroomio/commit/c1d023d6e561c2d2b13014c53441d7dbc8f6d323) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39968587)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->