### PR TITLE
fix(sidebar): restore menu button styles on disabled nav items

### DIFF
--- a/apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/nav-main.svelte
+++ b/apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/nav-main.svelte
@@ -32,11 +32,7 @@
                         <HoverableItem>
                           {#snippet children(isHovered)}
                             {#if item.disabled}
-                              <span
-                                {...props}
-                                aria-disabled="true"
-                                class="flex cursor-not-allowed items-center gap-2 opacity-50"
-                              >
+                              <span {...props} aria-disabled="true">
                                 {#if item.icon}
                                   {@const Icon = item.icon}
                                   <Icon {isHovered} size={16} class="custom" />
@@ -71,11 +67,7 @@
                     <HoverableItem>
                       {#snippet children(isHovered)}
                         {#if item.disabled}
-                          <span
-                            {...props}
-                            aria-disabled="true"
-                            class="flex cursor-not-allowed items-center gap-2 opacity-50"
-                          >
+                          <span {...props} aria-disabled="true">
                             {#if item.icon}
                               {@const Icon = item.icon}
                               <Icon {isHovered} size={16} class="custom" />


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (place issue number here without bracket)

<!-- Please provide a screenshots or upload a video for visual changes to speed up reviews -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the hardcoded `class="flex cursor-not-allowed items-center gap-2 opacity-50"` attribute from the disabled nav item `<span>` elements, replacing it with the `props` spread from `Sidebar.MenuButton`'s child snippet. The bug was that placing an explicit `class=` attribute after `{...props}` in Svelte overrides `props.class`, discarding all `sidebarMenuButtonVariants` styles (sizing, padding, typography, etc.) from disabled items.

- **Root cause fixed**: The explicit `class` override stripped `sidebarMenuButtonVariants` styling from disabled nav items; removing it allows `props.class` to carry all variant styles including `aria-disabled:pointer-events-none` and `aria-disabled:opacity-50`.
- **Styling restored**: Disabled items now share the same base visual treatment as enabled items (proper dimensions, font size, padding) with the `opacity-50` dimming applied via the `aria-disabled` variant selector.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change correctly removes a class override that was silently discarding component-level styles from disabled nav items.

The fix is minimal and well-targeted: removing an explicit `class=` attribute that was overwriting `props.class` in both disabled-item branches. The `sidebarMenuButtonVariants` base already includes `aria-disabled:opacity-50` and `aria-disabled:pointer-events-none`, so setting `aria-disabled="true"` on the span is sufficient to reproduce the intended disabled styling without the override. No logic changes, no new dependencies, and both the collapsible-trigger and non-collapsible item paths are handled consistently.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/nav-main.svelte | Removes hardcoded class override on disabled nav item spans so sidebarMenuButtonVariants styles (including aria-disabled opacity/pointer-events) are correctly applied via props spread. Fix is applied consistently to both collapsible-trigger and non-collapsible menu item paths. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sidebar.MenuButton child snippet] -->|passes props| B[props.class = sidebarMenuButtonVariants]

    B --> C{item.disabled?}

    C -->|Yes - BEFORE| D["span with {...props} then explicit class= override"]
    D --> E[explicit class= OVERRIDES props.class]
    E --> F[variant styles LOST: sizing, font, padding]

    C -->|Yes - AFTER| G["span with {...props} aria-disabled='true' only"]
    G --> H[props.class fully applied]
    H --> I[aria-disabled:opacity-50 activates]
    H --> J[aria-disabled:pointer-events-none activates]
    H --> K[flex, gap-2, items-center, sizing all present]

    C -->|No| L["a href={item.url} with {...props}"]
    L --> M[props.class applied normally]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Sidebar.MenuButton child snippet] -->|passes props| B[props.class = sidebarMenuButtonVariants]

    B --> C{item.disabled?}

    C -->|Yes - BEFORE| D["span with {...props} then explicit class= override"]
    D --> E[explicit class= OVERRIDES props.class]
    E --> F[variant styles LOST: sizing, font, padding]

    C -->|Yes - AFTER| G["span with {...props} aria-disabled='true' only"]
    G --> H[props.class fully applied]
    H --> I[aria-disabled:opacity-50 activates]
    H --> J[aria-disabled:pointer-events-none activates]
    H --> K[flex, gap-2, items-center, sizing all present]

    C -->|No| L["a href={item.url} with {...props}"]
    L --> M[props.class applied normally]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; of https://github.co..."](https://github.com/classroomio/classroomio/commit/e6899c27c302fbeeea3bbf310be3d0709dc4afe1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39968862)</sub>

<!-- /greptile_comment -->