### PR TITLE
fix(api): update openapi upload script env import path

### DIFF
--- a/apps/api/scripts/upload-openapi-spec.js
+++ b/apps/api/scripts/upload-openapi-spec.js
@@ -145,7 +145,7 @@ require('dotenv/config');
 var client_s3_1 = require('@aws-sdk/client-s3');
 var fs_1 = require('fs');
 var app_1 = require('../src/app');
-var env_1 = require('../src/config/env');
+var env_1 = require('@cio/core/config/env');
 var hono_openapi_1 = require('hono-openapi');
 var path_1 = require('path');
 function filterPublicApiSpec(spec) {

--- a/apps/api/scripts/upload-openapi-spec.ts
+++ b/apps/api/scripts/upload-openapi-spec.ts
@@ -6,7 +6,7 @@ import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { mkdirSync, writeFileSync } from 'fs';
 
 import { app } from '../src/app';
-import { env } from '../src/config/env';
+import { env } from '@cio/core/config/env';
 import { generateSpecs } from 'hono-openapi';
 import { join } from 'path';
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `generate-and-upload-openapi` CI job failure caused by a stale import in the OpenAPI upload script.

The `env` module was moved from `apps/api/src/config/env` to `@cio/core/config/env`, but `upload-openapi-spec.ts` (and its compiled `.js` sibling) still referenced the old path, causing:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../apps/api/src/config/env'
```

## Changes

- Update `apps/api/scripts/upload-openapi-spec.ts` to import `env` from `@cio/core/config/env`
- Update `apps/api/scripts/upload-openapi-spec.js` to match

## Testing

Ran locally:

```bash
cd apps/api && pnpm run upload:openapi
```

Result: OpenAPI spec generated and saved to `dist/openapi/public-api/openapi.json` successfully (R2 upload skipped without credentials, as expected).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a664e821-20f9-4366-b78e-527bb2d2b33e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a664e821-20f9-4366-b78e-527bb2d2b33e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken CI job by correcting two stale import paths in the OpenAPI upload script — the `env` module was previously moved from `apps/api/src/config/env` to `@cio/core/config/env`, but the script was never updated.

- `upload-openapi-spec.ts`: updated TypeScript import to point at `@cio/core/config/env`, which is correctly exported via the `"./config/*"` entry in `packages/core/package.json`.
- `upload-openapi-spec.js`: matching update in the pre-compiled JavaScript sibling so the script runs without requiring a local build step.

<h3>Confidence Score: 5/5</h3>

Two-line fix updating stale module paths; both the TypeScript source and its compiled JS sibling are updated consistently, and the target module exports env correctly.

The change is minimal and surgical — a single import path corrected in both the .ts source and its pre-built .js companion. The target package (@cio/core) exports ./config/* in its package.json, confirming the new path resolves correctly. The old path (apps/api/src/config/env) no longer exists, confirming the original failure was genuine.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/scripts/upload-openapi-spec.ts | Single-line import fix: env now imported from @cio/core/config/env, matching the current module location. |
| apps/api/scripts/upload-openapi-spec.js | Matching require() path update in the compiled JS sibling; kept in sync with the TypeScript source. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Script as upload-openapi-spec.ts
    participant Core as @cio/core/config/env
    participant App as ../src/app
    participant Hono as hono-openapi
    participant R2 as Cloudflare R2

    Script->>Core: "import { env }"
    Script->>App: "import { app }"
    Script->>Hono: generateSpecs(app)
    Hono-->>Script: OpenAPI spec
    Script->>Script: filterPublicApiSpec(spec)
    Script->>Script: saveLocalSpec(spec)
    alt R2 credentials present
        Script->>R2: PutObjectCommand (dated key)
        Script->>R2: PutObjectCommand (latest key)
    else No credentials
        Script->>Script: skip upload, warn
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Script as upload-openapi-spec.ts
    participant Core as @cio/core/config/env
    participant App as ../src/app
    participant Hono as hono-openapi
    participant R2 as Cloudflare R2

    Script->>Core: "import { env }"
    Script->>App: "import { app }"
    Script->>Hono: generateSpecs(app)
    Hono-->>Script: OpenAPI spec
    Script->>Script: filterPublicApiSpec(spec)
    Script->>Script: saveLocalSpec(spec)
    alt R2 credentials present
        Script->>R2: PutObjectCommand (dated key)
        Script->>R2: PutObjectCommand (latest key)
    else No credentials
        Script->>Script: skip upload, warn
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(api): update openapi upload script e..."](https://github.com/classroomio/classroomio/commit/13b94574619b7a7e7a0345896484cd61bda58926) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40263983)</sub>

<!-- /greptile_comment -->