### PR TITLE
fix(dashboard): use default highlighting for API quick-start snippets

### DIFF
--- a/apps/dashboard/src/lib/features/automation/pages/api.svelte
+++ b/apps/dashboard/src/lib/features/automation/pages/api.svelte
@@ -116,7 +116,7 @@
       <div class="rounded-lg border border-amber-200 bg-amber-50 p-4">
         <p class="ui:text-amber-800 text-sm font-medium">{$t('automation.api.keys.secret_once')}</p>
         <div class="mt-3">
-          <Code.Root code={generatedSecret} lang="bash" hideLines={true} class="ui:break-all ui:text-xs">
+          <Code.Root code={generatedSecret} hideLines={true} class="ui:break-all ui:text-xs">
             <Code.CopyButton />
           </Code.Root>
         </div>
@@ -216,7 +216,7 @@
 
         <Tabs.Content value="curl" class="mt-4">
           <Code.Overflow>
-            <Code.Root code={getPublicApiCurlSnippet(generatedSecret)} lang="bash">
+            <Code.Root code={getPublicApiCurlSnippet(generatedSecret)}>
               <Code.CopyButton />
             </Code.Root>
           </Code.Overflow>
@@ -224,7 +224,7 @@
 
         <Tabs.Content value="javascript" class="mt-4">
           <Code.Overflow>
-            <Code.Root code={getPublicApiJavaScriptSnippet(generatedSecret)} lang="javascript">
+            <Code.Root code={getPublicApiJavaScriptSnippet(generatedSecret)}>
               <Code.CopyButton />
             </Code.Root>
           </Code.Overflow>
@@ -232,7 +232,7 @@
 
         <Tabs.Content value="python" class="mt-4">
           <Code.Overflow>
-            <Code.Root code={getPublicApiPythonSnippet(generatedSecret)} lang="python">
+            <Code.Root code={getPublicApiPythonSnippet(generatedSecret)}>
               <Code.CopyButton />
             </Code.Root>
           </Code.Overflow>
@@ -240,7 +240,7 @@
 
         <Tabs.Content value="go" class="mt-4">
           <Code.Overflow>
-            <Code.Root code={getPublicApiGoSnippet(generatedSecret)} lang="go">
+            <Code.Root code={getPublicApiGoSnippet(generatedSecret)}>
               <Code.CopyButton />
             </Code.Root>
           </Code.Overflow>

--- a/apps/dashboard/src/lib/features/ui/navigation/breadcrumb.ts
+++ b/apps/dashboard/src/lib/features/ui/navigation/breadcrumb.ts
@@ -58,7 +58,7 @@ export function generateBreadcrumbs(
     const href = matchedNavItem.useHashUrl ? `${currentOrgPath}${parentCrumbPath}` : matchedNavItem.url;
 
     breadcrumbs.push({
-      label: t(matchedNavItem.title),
+      label: matchedNavItem.title,
       href: href
     });
   }
@@ -68,7 +68,7 @@ export function generateBreadcrumbs(
     const subItem = matchedNavItem.items.find((sub) => isActive(pathWithQuery, sub.url, undefined, true));
     if (subItem) {
       breadcrumbs.push({
-        label: t(subItem.title),
+        label: subItem.title,
         href: subItem.url
       });
       return breadcrumbs;
@@ -84,7 +84,7 @@ export function generateBreadcrumbs(
       const activeSub = matchedNavItem.items.find((sub) => isActive(pathname, sub.url, sub.matchPattern, true));
       if (activeSub) {
         breadcrumbs.push({
-          label: t(activeSub.title),
+          label: activeSub.title,
           href: activeSub.url
         });
 

--- a/apps/dashboard/src/lib/features/ui/navigation/breadcrumb.ts
+++ b/apps/dashboard/src/lib/features/ui/navigation/breadcrumb.ts
@@ -58,7 +58,7 @@ export function generateBreadcrumbs(
     const href = matchedNavItem.useHashUrl ? `${currentOrgPath}${parentCrumbPath}` : matchedNavItem.url;
 
     breadcrumbs.push({
-      label: matchedNavItem.title,
+      label: t(matchedNavItem.title),
       href: href
     });
   }
@@ -68,7 +68,7 @@ export function generateBreadcrumbs(
     const subItem = matchedNavItem.items.find((sub) => isActive(pathWithQuery, sub.url, undefined, true));
     if (subItem) {
       breadcrumbs.push({
-        label: subItem.title,
+        label: t(subItem.title),
         href: subItem.url
       });
       return breadcrumbs;
@@ -84,7 +84,7 @@ export function generateBreadcrumbs(
       const activeSub = matchedNavItem.items.find((sub) => isActive(pathname, sub.url, sub.matchPattern, true));
       if (activeSub) {
         breadcrumbs.push({
-          label: activeSub.title,
+          label: t(activeSub.title),
           href: activeSub.url
         });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `ShikiError: Language 'python' not found` on the org API page when switching quick-start tabs.

`@cio/ui` only bundles bash, diff, javascript, json, svelte, and typescript. The API page was passing `lang="python"`, `lang="go"`, etc.

Remove per-tab `lang` props so all snippets use `Code.Root`'s default `typescript` highlighting.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae9536d9-e754-46c1-abd6-d771c111c099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae9536d9-e754-46c1-abd6-d771c111c099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `ShikiError: Language 'python' not found` runtime crash on the org API page by removing `lang` props from all `Code.Root` snippets so they fall back to the default `typescript` highlighting. The root cause is that `@cio/ui`'s Shiki bundle only ships `bash`, `diff`, `javascript`, `json`, `svelte`, and `typescript`, making `lang="python"` and `lang="go"` fatal at runtime.

- Removes `lang="python"` and `lang="go"` from the Python and Go quick-start tabs, eliminating the crash — this is the correct targeted fix.
- Also removes `lang="bash"` (curl tab + generated-secret block) and `lang="javascript"` (JavaScript tab), which were already bundled and highlighting correctly; those snippets will now render with TypeScript tokenisation instead of their native grammars.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the crash is fixed and no functionality is broken; the only downside is that curl and JavaScript snippets lose their correct syntax colouring.

The change stops the ShikiError crash for Python and Go tabs, which is the primary goal. However, bash and javascript were already in the bundled language list and highlighted correctly before; stripping their lang props is an overshoot that degrades syntax highlighting for those two tabs unnecessarily.

apps/dashboard/src/lib/features/automation/pages/api.svelte — the curl and JavaScript Code.Root blocks had their lang props removed even though both languages are bundled.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/automation/pages/api.svelte | Removes all lang props from Code.Root to fix ShikiError for python/go; but also drops lang="bash" and lang="javascript" which are bundled and would have highlighted correctly. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects tab] --> B{Active tab}
    B -->|curl| C["Code.Root (no lang)"]
    B -->|javascript| D["Code.Root (no lang)"]
    B -->|python| E["Code.Root (no lang)"]
    B -->|go| F["Code.Root (no lang)"]

    C --> G["Default: lang='typescript'"]
    D --> G
    E --> G
    F --> G

    G --> H[Shiki highlights with TypeScript grammar]

    subgraph Bundled Languages
        L1[bash ✓]
        L2[javascript ✓]
        L3[typescript ✓]
        L4[json ✓]
        L5[svelte ✓]
        L6[diff ✓]
        L7[python ✗ not bundled]
        L8[go ✗ not bundled]
    end

    style L7 fill:#f88,stroke:#c00
    style L8 fill:#f88,stroke:#c00
    style L1 fill:#8f8,stroke:#080
    style L2 fill:#8f8,stroke:#080
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User selects tab] --> B{Active tab}
    B -->|curl| C["Code.Root (no lang)"]
    B -->|javascript| D["Code.Root (no lang)"]
    B -->|python| E["Code.Root (no lang)"]
    B -->|go| F["Code.Root (no lang)"]

    C --> G["Default: lang='typescript'"]
    D --> G
    E --> G
    F --> G

    G --> H[Shiki highlights with TypeScript grammar]

    subgraph Bundled Languages
        L1[bash ✓]
        L2[javascript ✓]
        L3[typescript ✓]
        L4[json ✓]
        L5[svelte ✓]
        L6[diff ✓]
        L7[python ✗ not bundled]
        L8[go ✗ not bundled]
    end

    style L7 fill:#f88,stroke:#c00
    style L8 fill:#f88,stroke:#c00
    style L1 fill:#8f8,stroke:#080
    style L2 fill:#8f8,stroke:#080
```

</a>

<sub>Reviews (1): Last reviewed commit: ["revert(dashboard): drop breadcrumb i18n ..."](https://github.com/classroomio/classroomio/commit/49facb4a40b59917e3e498a821a7048b6e12cc4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41343939)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->