### PR TITLE
fix(api): return Zod validation errors from public API routes

### DIFF
--- a/apps/api/src/routes/v1/audience.ts
+++ b/apps/api/src/routes/v1/audience.ts
@@ -17,7 +17,7 @@ import {
 import { Hono } from '@api/utils/hono';
 import { automationKeyMiddleware } from '@api/middlewares/automation-key';
 import { automationKeyScopesMiddleware } from '@api/middlewares/automation-key-scopes';
-import { handleError } from '@api/utils/errors';
+import { handlePublicApiError } from '@api/utils/errors';
 import { describeRoute, validator } from 'hono-openapi';
 
 const AudienceListResponse = {
@@ -87,7 +87,7 @@ export const v1AudienceRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to list audience members');
+        return handlePublicApiError(c, error, 'Failed to list audience members');
       }
     }
   )
@@ -128,7 +128,7 @@ export const v1AudienceRouter = new Hono()
           201
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to create audience member');
+        return handlePublicApiError(c, error, 'Failed to create audience member');
       }
     }
   )
@@ -168,7 +168,7 @@ export const v1AudienceRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to assign audience to courses');
+        return handlePublicApiError(c, error, 'Failed to assign audience to courses');
       }
     }
   )
@@ -208,7 +208,7 @@ export const v1AudienceRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to fetch audience member');
+        return handlePublicApiError(c, error, 'Failed to fetch audience member');
       }
     }
   )
@@ -249,7 +249,7 @@ export const v1AudienceRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to remove audience member');
+        return handlePublicApiError(c, error, 'Failed to remove audience member');
       }
     }
   )
@@ -293,7 +293,7 @@ export const v1AudienceRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to update audience member');
+        return handlePublicApiError(c, error, 'Failed to update audience member');
       }
     }
   );

--- a/apps/api/src/routes/v1/courses.ts
+++ b/apps/api/src/routes/v1/courses.ts
@@ -19,7 +19,7 @@ import {
 import { Hono } from '@api/utils/hono';
 import { automationKeyMiddleware } from '@api/middlewares/automation-key';
 import { automationKeyScopesMiddleware } from '@api/middlewares/automation-key-scopes';
-import { handleError } from '@api/utils/errors';
+import { handlePublicApiError } from '@api/utils/errors';
 import { describeRoute, validator } from 'hono-openapi';
 
 const CoursesListResponse = {
@@ -76,7 +76,7 @@ export const v1CoursesRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to list courses');
+        return handlePublicApiError(c, error, 'Failed to list courses');
       }
     }
   )
@@ -117,7 +117,7 @@ export const v1CoursesRouter = new Hono()
           201
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to create course');
+        return handlePublicApiError(c, error, 'Failed to create course');
       }
     }
   )
@@ -157,7 +157,7 @@ export const v1CoursesRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to list course students');
+        return handlePublicApiError(c, error, 'Failed to list course students');
       }
     }
   )
@@ -197,7 +197,7 @@ export const v1CoursesRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to export course');
+        return handlePublicApiError(c, error, 'Failed to export course');
       }
     }
   )
@@ -237,7 +237,7 @@ export const v1CoursesRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to fetch course structure');
+        return handlePublicApiError(c, error, 'Failed to fetch course structure');
       }
     }
   )
@@ -281,7 +281,7 @@ export const v1CoursesRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to update course structure');
+        return handlePublicApiError(c, error, 'Failed to update course structure');
       }
     }
   )
@@ -321,7 +321,7 @@ export const v1CoursesRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to fetch course');
+        return handlePublicApiError(c, error, 'Failed to fetch course');
       }
     }
   )
@@ -364,7 +364,7 @@ export const v1CoursesRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to update course');
+        return handlePublicApiError(c, error, 'Failed to update course');
       }
     }
   )
@@ -404,7 +404,7 @@ export const v1CoursesRouter = new Hono()
           200
         );
       } catch (error) {
-        return handleError(c, error, 'Failed to delete course');
+        return handlePublicApiError(c, error, 'Failed to delete course');
       }
     }
   );

--- a/apps/api/src/services/course-import/course-import.ts
+++ b/apps/api/src/services/course-import/course-import.ts
@@ -46,6 +46,7 @@ import {
 import { getCourseOrganizationId } from '@cio/db/queries/tag';
 import { assignCourseTagsByName } from '@api/services/tag';
 import { generateSlug } from '@cio/utils/functions';
+import { ZodError } from 'zod';
 
 type DraftSummary = {
   sectionCount: number;
@@ -537,7 +538,7 @@ export async function createCourseImportDraftService(orgId: string, profileId: s
       sourceArtifacts: data.sourceArtifacts ?? data.draft.sourceReferences ?? []
     });
   } catch (error) {
-    if (error instanceof AppError) {
+    if (error instanceof AppError || error instanceof ZodError) {
       throw error;
     }
 
@@ -579,7 +580,7 @@ export async function getCourseImportStructureService(orgId: string, courseId: s
   try {
     return buildCourseStructureSnapshot(orgId, courseId);
   } catch (error) {
-    if (error instanceof AppError) {
+    if (error instanceof AppError || error instanceof ZodError) {
       throw error;
     }
 
@@ -600,7 +601,7 @@ export async function getCourseImportDraftService(orgId: string, draftId: string
 
     return draft;
   } catch (error) {
-    if (error instanceof AppError) {
+    if (error instanceof AppError || error instanceof ZodError) {
       throw error;
     }
 
@@ -641,7 +642,7 @@ export async function updateCourseImportDraftService(orgId: string, draftId: str
 
     return updated;
   } catch (error) {
-    if (error instanceof AppError) {
+    if (error instanceof AppError || error instanceof ZodError) {
       throw error;
     }
 
@@ -845,7 +846,7 @@ export async function publishCourseImportDraftService(
       localeCount: new Set(draft.lessonLanguages.map((item) => item.locale)).size
     };
   } catch (error) {
-    if (error instanceof AppError) {
+    if (error instanceof AppError || error instanceof ZodError) {
       throw error;
     }
 
@@ -1132,7 +1133,7 @@ export async function publishCourseImportDraftToExistingCourseService(
       localeCount: new Set(draft.lessonLanguages.map((item) => item.locale)).size
     };
   } catch (error) {
-    if (error instanceof AppError) {
+    if (error instanceof AppError || error instanceof ZodError) {
       throw error;
     }
 

--- a/apps/api/src/utils/__tests__/errors.test.ts
+++ b/apps/api/src/utils/__tests__/errors.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { z, ZodError } from 'zod';
+import { Hono } from 'hono';
+
+import { AppError, ErrorCodes, formatZodErrorMessage, handlePublicApiError } from '@api/utils/errors';
+
+describe('formatZodErrorMessage', () => {
+  it('formats issue paths and messages', () => {
+    const schema = z.object({
+      course: z.object({
+        type: z.enum(['LIVE_CLASS', 'SELF_PACED', 'COMPLIANCE'])
+      })
+    });
+
+    try {
+      schema.parse({ course: { type: 'INVALID' } });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ZodError);
+      expect(formatZodErrorMessage(error as ZodError)).toContain('course.type:');
+    }
+  });
+});
+
+describe('handlePublicApiError', () => {
+  const app = new Hono().get('/test', async (c) => {
+    try {
+      z.object({ allowNewStudent: z.boolean() }).parse({ allowNewStudent: undefined });
+      return c.json({ success: true });
+    } catch (error) {
+      return handlePublicApiError(c, error, 'Failed to fetch course structure');
+    }
+  });
+
+  it('returns validation details for ZodError instead of INTERNAL_ERROR', async () => {
+    const response = await app.request('/test');
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      success: false,
+      error: expect.stringContaining('allowNewStudent'),
+      code: ErrorCodes.VALIDATION_ERROR,
+      field: 'allowNewStudent'
+    });
+  });
+
+  it('delegates AppError handling to handleError', async () => {
+    const errorApp = new Hono().get('/test', async (c) => {
+      try {
+        throw new AppError('Course not found', ErrorCodes.COURSE_NOT_FOUND, 404);
+      } catch (error) {
+        return handlePublicApiError(c, error, 'Failed to fetch course');
+      }
+    });
+
+    const response = await errorApp.request('/test');
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toEqual({
+      success: false,
+      error: 'Course not found',
+      code: ErrorCodes.COURSE_NOT_FOUND
+    });
+  });
+});

--- a/apps/api/src/utils/__tests__/errors.test.ts
+++ b/apps/api/src/utils/__tests__/errors.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from 'vitest';
 import { z, ZodError } from 'zod';
 import { Hono } from 'hono';
 
+import { ZCourseType } from '@cio/utils/validation/course';
 import { AppError, ErrorCodes, formatZodErrorMessage, handlePublicApiError } from '@api/utils/errors';
 
 describe('formatZodErrorMessage', () => {
   it('formats issue paths and messages', () => {
     const schema = z.object({
       course: z.object({
-        type: z.enum(['LIVE_CLASS', 'SELF_PACED', 'COMPLIANCE'])
+        type: ZCourseType
       })
     });
 

--- a/apps/api/src/utils/errors.ts
+++ b/apps/api/src/utils/errors.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
+import { ZodError } from 'zod';
 
 import { AppError, ErrorCodes, type ErrorCode } from '@cio/utils/errors';
 
@@ -17,6 +18,25 @@ export interface ErrorResponse {
   error: string;
   code: string;
   field?: string;
+}
+
+function getZodErrorField(error: ZodError): string | undefined {
+  const firstIssue = error.issues[0];
+  if (!firstIssue || firstIssue.path.length === 0) {
+    return undefined;
+  }
+
+  return firstIssue.path.map(String).join('.');
+}
+
+export function formatZodErrorMessage(error: ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const fieldPath = issue.path.length > 0 ? `${issue.path.map(String).join('.')}: ` : '';
+
+      return `${fieldPath}${issue.message}`;
+    })
+    .join('; ');
 }
 
 /**
@@ -69,4 +89,31 @@ export const handleError = (
     },
     500
   );
+};
+
+/**
+ * Handles errors for public API routes, surfacing Zod validation failures
+ * as 400 responses instead of generic 500 INTERNAL_ERROR payloads.
+ */
+export const handlePublicApiError = (
+  c: Context,
+  error: unknown,
+  fallbackMessage: string = 'An unexpected error occurred',
+  fallbackCode?: string
+) => {
+  if (error instanceof ZodError) {
+    console.error('Error in route:', error);
+
+    return c.json<ErrorResponse>(
+      {
+        success: false,
+        error: formatZodErrorMessage(error),
+        code: ErrorCodes.VALIDATION_ERROR,
+        field: getZodErrorField(error)
+      },
+      400
+    );
+  }
+
+  return handleError(c, error, fallbackMessage, fallbackCode);
 };

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -24,8 +24,6 @@ import type { AnswerData } from '@cio/question-types';
 import { COURSE_TYPE_VALUES } from '@cio/utils/constants/course-type';
 import { sql } from 'drizzle-orm';
 
-export { COURSE_TYPE_VALUES };
-
 export const courseType = pgEnum('COURSE_TYPE', [...COURSE_TYPE_VALUES]);
 export const locale = pgEnum('LOCALE', ['en', 'hi', 'fr', 'pt', 'de', 'vi', 'ru', 'es', 'pl', 'da']);
 export const plan = pgEnum('PLAN', ['EARLY_ADOPTER', 'ENTERPRISE', 'BASIC']);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -21,9 +21,12 @@ import {
 } from 'drizzle-orm/pg-core';
 
 import type { AnswerData } from '@cio/question-types';
+import { COURSE_TYPE_VALUES } from '@cio/utils/constants/course-type';
 import { sql } from 'drizzle-orm';
 
-export const courseType = pgEnum('COURSE_TYPE', ['SELF_PACED', 'LIVE_CLASS', 'COMPLIANCE', 'PUBLIC']);
+export { COURSE_TYPE_VALUES };
+
+export const courseType = pgEnum('COURSE_TYPE', [...COURSE_TYPE_VALUES]);
 export const locale = pgEnum('LOCALE', ['en', 'hi', 'fr', 'pt', 'de', 'vi', 'ru', 'es', 'pl', 'da']);
 export const plan = pgEnum('PLAN', ['EARLY_ADOPTER', 'ENTERPRISE', 'BASIC']);
 export const courseImportSourceType = pgEnum('COURSE_IMPORT_SOURCE_TYPE', ['prompt', 'pdf', 'course']);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -689,7 +689,7 @@ export const course = pgTable(
       }[];
       grading?: boolean;
       lessonDownload?: boolean;
-      allowNewStudent: boolean;
+      allowNewStudent?: boolean;
       /** Teacher-authored HTML sent in the welcome email after a student enrolls. */
       welcomeEmailMessage?: string | null;
       /** IANA timezone for this course's live sessions (display + scheduling). */

--- a/packages/utils/src/constants/course-type.ts
+++ b/packages/utils/src/constants/course-type.ts
@@ -1,0 +1,4 @@
+/** Postgres `COURSE_TYPE` enum values — shared by Drizzle schema and Zod validation. */
+export const COURSE_TYPE_VALUES = ['SELF_PACED', 'LIVE_CLASS', 'COMPLIANCE', 'PUBLIC'] as const;
+
+export type TCourseType = (typeof COURSE_TYPE_VALUES)[number];

--- a/packages/utils/src/constants/index.ts
+++ b/packages/utils/src/constants/index.ts
@@ -1,6 +1,7 @@
 export * from './roles';
 export * from './org';
 export * from './content';
+export * from './course-type';
 export * from './domains';
 export * from './embeds';
 export * from './error-codes';

--- a/packages/utils/src/validation/course-import/course-import.ts
+++ b/packages/utils/src/validation/course-import/course-import.ts
@@ -1,6 +1,7 @@
 import * as z from 'zod';
 
 import { ZComplianceSettings, ZCourseMetadata } from '../course/course';
+import { ZCourseType } from '../course/course-type';
 import { ZExerciseQuestionTypeId } from '../exercise/exercise';
 
 const ZSupportedLocale = z.enum(['en', 'hi', 'fr', 'pt', 'de', 'vi', 'ru', 'es', 'pl', 'da']);
@@ -26,7 +27,7 @@ export const ZCourseImportDraftCourse = z
   .object({
     title: z.string().min(1),
     description: z.string().min(1),
-    type: z.enum(['LIVE_CLASS', 'SELF_PACED', 'COMPLIANCE']),
+    type: ZCourseType,
     locale: ZSupportedLocale.default('en'),
     metadata: ZCourseMetadata.optional(),
     compliance: ZComplianceSettings.optional()
@@ -225,7 +226,7 @@ export type TCourseImportDraftUpdate = z.infer<typeof ZCourseImportDraftUpdate>;
 export const ZCourseImportDraftPublishBase = z.object({
   title: z.string().min(1).optional(),
   description: z.string().min(1).optional(),
-  type: z.enum(['LIVE_CLASS', 'SELF_PACED', 'COMPLIANCE']).optional(),
+  type: ZCourseType.optional(),
   metadata: ZCourseMetadata.optional(),
   compliance: ZComplianceSettings.optional(),
   bannerImageUrl: z.string().url().optional(),

--- a/packages/utils/src/validation/course/course-type.ts
+++ b/packages/utils/src/validation/course/course-type.ts
@@ -1,0 +1,8 @@
+import * as z from 'zod';
+
+import { COURSE_TYPE_VALUES, type TCourseType } from '../../constants/course-type';
+
+/** Zod schema for Postgres `COURSE_TYPE` — values come from shared constants. */
+export const ZCourseType = z.enum(COURSE_TYPE_VALUES);
+
+export { COURSE_TYPE_VALUES, type TCourseType };

--- a/packages/utils/src/validation/course/course.ts
+++ b/packages/utils/src/validation/course/course.ts
@@ -317,6 +317,10 @@ function preprocessCourseMetadata(value: unknown): unknown {
     metadata.instructor = instructor;
   }
 
+  if (metadata.allowNewStudent == null) {
+    metadata.allowNewStudent = true;
+  }
+
   return metadata;
 }
 
@@ -366,7 +370,7 @@ const ZCourseMetadataFields = z.object({
   lessonTabsOrder: ZCourseLessonTabsOrder.optional(),
   grading: z.boolean().optional(),
   lessonDownload: z.boolean().optional(),
-  allowNewStudent: z.boolean(),
+  allowNewStudent: z.boolean().default(true),
   welcomeEmailMessage: z.string().max(20000).nullish(),
   sessionTimezone: z.string().max(64).nullish(),
   sectionDisplay: z.record(z.string(), z.boolean()).optional(),

--- a/packages/utils/src/validation/course/course.ts
+++ b/packages/utils/src/validation/course/course.ts
@@ -2,6 +2,7 @@ import * as z from 'zod';
 
 import { ALLOWED_CONTENT_TYPES, ALLOWED_DOCUMENT_TYPES } from '../constants';
 import { ZCourseCalloutInput } from './callout';
+import { ZCourseType } from './course-type';
 
 export const ZGetRecommendedCourses = z.object({
   limit: z.string().transform(Number).pipe(z.number().min(1).max(50)).optional(),
@@ -271,7 +272,7 @@ export type TComplianceSettings = z.infer<typeof ZComplianceSettings>;
 export const ZCourseCreateBase = z.object({
   title: z.string().min(1),
   description: z.string().min(1),
-  type: z.enum(['LIVE_CLASS', 'SELF_PACED', 'COMPLIANCE', 'PUBLIC']),
+  type: ZCourseType,
   organizationId: z.string().min(1),
   compliance: ZComplianceSettings.optional()
 });
@@ -408,7 +409,7 @@ export type TCertificationSettings = z.infer<typeof ZCertificationSettings>;
 export const ZCourseUpdateBase = z.object({
   title: z.string().min(1).optional(),
   description: z.string().min(1).optional(),
-  type: z.enum(['LIVE_CLASS', 'SELF_PACED', 'COMPLIANCE', 'PUBLIC']).optional(),
+  type: ZCourseType.optional(),
   logo: z.string().optional(),
   slug: z.string().optional(),
   isPublished: z.boolean().optional(),

--- a/packages/utils/src/validation/course/index.ts
+++ b/packages/utils/src/validation/course/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './course';
+export * from './course-type';
 export * from './callout';
 export * from './compliance';
 export * from './public-course';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes public API routes returning generic `500 INTERNAL_ERROR` responses when internal Zod validation fails (for example, on `GET /public-api/v1/courses/{courseId}/structure` when stored course data does not match the course-import draft schema).

- Adds `handlePublicApiError` that maps `ZodError` to `400` with `VALIDATION_ERROR`, a readable message, and the first failing field path
- Switches all `/public-api/v1` route handlers (`courses`, `audience`) to use the new handler
- Updates course-import services to rethrow `ZodError` instead of wrapping it as a 500 `AppError`
- Centralizes `COURSE_TYPE_VALUES` in `@cio/utils/constants/course-type` and uses it for both `ZCourseType` validation and the Drizzle `COURSE_TYPE` pgEnum (no circular `@cio/utils` → `@cio/db` dependency; includes `PUBLIC` in course-import schemas)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Call `GET /public-api/v1/courses/{courseId}/structure` for a course whose stored `type` or `metadata.allowNewStudent` is invalid against the import schema.
2. Confirm the response is `400` with:
   - `success: false`
   - `code: VALIDATION_ERROR`
   - `error` containing the Zod issue message (e.g. `course.type: Invalid option...`)
   - `field` set to the first failing path (e.g. `course.type`)
3. Call the same endpoint for a `PUBLIC` course and confirm it no longer fails type validation.
4. Run `pnpm --filter @cio/api exec vitest run src/utils/__tests__/errors.test.ts`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Ran `pnpm --filter @cio/api build`
- [x] Checked for warnings, there are none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2981254-5d5b-4416-bb6f-89148f372c1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2981254-5d5b-4416-bb6f-89148f372c1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes public API routes returning opaque `500 INTERNAL_ERROR` when stored course data fails Zod validation (e.g. a `PUBLIC` course whose `type` was not accepted by the import draft schema). It introduces `handlePublicApiError` that intercepts `ZodError` and returns `400 VALIDATION_ERROR` with a human-readable field path, centralizes `COURSE_TYPE_VALUES` to eliminate a potential circular dependency, and adds `PUBLIC` to course-import schemas so `PUBLIC` courses no longer fail validation.

- Adds `handlePublicApiError` in `errors.ts` and wires it into all 15 public-API route handlers (courses + audience).
- Extracts `COURSE_TYPE_VALUES` to `@cio/utils/constants/course-type` so both the Drizzle `pgEnum` and `ZCourseType` derive from a single source of truth.
- Makes `allowNewStudent` optional/defaulted in both the Drizzle type and `ZCourseMetadata`, preventing validation failures on older records that pre-date the field.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix works end-to-end at the route level regardless of the service-layer quirk noted.

The core fix is correct: `handlePublicApiError` in the route handler catches ZodErrors that propagate as rejected Promises from the async service functions and returns a proper 400. The `|| error instanceof ZodError` addition in `getCourseImportStructureService`'s catch block is dead code (no `await` on the inner call), but this is a pre-existing pattern and the intended behavior is still achieved. All other service catch additions are effective. The constant centralization and `allowNewStudent` default changes are straightforward and low-risk.

`apps/api/src/services/course-import/course-import.ts` — the `getCourseImportStructureService` catch block's ZodError guard is unreachable, worth a follow-up to either add `await` or remove the dead clause.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/errors.ts | Adds `handlePublicApiError` that maps ZodError to 400 VALIDATION_ERROR with field path; helpers are well-isolated and the existing `handleError` delegate path is preserved. |
| apps/api/src/services/course-import/course-import.ts | Adds ZodError to six service catch blocks so they re-throw instead of wrapping; the catch in `getCourseImportStructureService` is unreachable due to a pre-existing missing `await`, making the new guard there dead code (bug still fixed at route level). |
| apps/api/src/utils/__tests__/errors.test.ts | New test file covering ZodError formatting and `handlePublicApiError`; the `formatZodErrorMessage` test uses a bare try/catch without an assertion count guard, risking a silent pass if the schema never throws. |
| packages/utils/src/constants/course-type.ts | New shared constant file for `COURSE_TYPE_VALUES`; clean source-of-truth extraction, breaks potential circular dependency. |
| packages/utils/src/validation/course-import/course-import.ts | Replaces inline `z.enum(['LIVE_CLASS', 'SELF_PACED', 'COMPLIANCE'])` with `ZCourseType` (which includes `PUBLIC`), fixing the root cause of validation failures for PUBLIC courses. |
| packages/db/src/schema.ts | Drives `pgEnum` from shared `COURSE_TYPE_VALUES`; makes `allowNewStudent` optional in the DB TypeScript type, aligning with the Zod schema default. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant RouteHandler as Route Handler (courses/audience)
    participant Service as course-import Service
    participant Zod as ZCourseImportDraftPayload.parse()
    participant ErrorUtils as handlePublicApiError

    Client->>RouteHandler: GET /public-api/v1/courses/:id/structure
    RouteHandler->>Service: getCourseImportStructureService(orgId, courseId)
    Service->>Zod: ZCourseImportDraftPayload.parse(dbData)
    alt Stored data is valid
        Zod-->>Service: parsed draft
        Service-->>RouteHandler: CourseStructureSnapshot
        RouteHandler-->>Client: 200 OK
    else Stored data fails validation
        Zod-->>Service: throws ZodError (Promise rejects)
        Service-->>RouteHandler: ZodError propagates as rejected Promise
        RouteHandler->>ErrorUtils: handlePublicApiError(c, zodError, msg)
        ErrorUtils-->>Client: 400 VALIDATION_ERROR + field path
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant RouteHandler as Route Handler (courses/audience)
    participant Service as course-import Service
    participant Zod as ZCourseImportDraftPayload.parse()
    participant ErrorUtils as handlePublicApiError

    Client->>RouteHandler: GET /public-api/v1/courses/:id/structure
    RouteHandler->>Service: getCourseImportStructureService(orgId, courseId)
    Service->>Zod: ZCourseImportDraftPayload.parse(dbData)
    alt Stored data is valid
        Zod-->>Service: parsed draft
        Service-->>RouteHandler: CourseStructureSnapshot
        RouteHandler-->>Client: 200 OK
    else Stored data fails validation
        Zod-->>Service: throws ZodError (Promise rejects)
        Service-->>RouteHandler: ZodError propagates as rejected Promise
        RouteHandler->>ErrorUtils: handlePublicApiError(c, zodError, msg)
        ErrorUtils-->>Client: 400 VALIDATION_ERROR + field path
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore(db): drop unused COURSE\_TYPE\_VALUE..."](https://github.com/classroomio/classroomio/commit/682ef7cc0bb09f92fdd3d3353e1a8c3e2806ae0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41349098)</sub>

<!-- /greptile_comment -->