### PR TITLE
chore(ci): publish `latest` from main and retire the `edge` tag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,10 @@
 # Image version (only used by docker-compose.images.yaml — the pull-based stack)
 # ──────────────────────────────────────────────
 # Which published image tag to pull for api/dashboard/jobs.
-#   - Pin to a release (e.g. 1.4.2) in production so a merge to main never auto-breaks you.
-#   - "latest" = freshest main build (moves on every merge — rolling, may include unreleased code).
-#   - "1.4.2" / "1.4" / "1" = immutable, pinned releases (published on a v* git tag).
+#   - "latest" (below) = freshest main build; it MOVES on every merge to main (rolling, may
+#     include unreleased code), so a later `pull` can shift you to a newer build unannounced.
+#   - For production, PIN an exact release (e.g. 1.4.2) so a merge to main never auto-breaks you.
+#     "1.4.2" / "1.4" / "1" are immutable, published on a v* git tag.
 # Rollback = set this back to the previous version, then `... pull && up -d`.
 CIO_VERSION=latest
 

--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,9 @@
 # Image version (only used by docker-compose.images.yaml — the pull-based stack)
 # ──────────────────────────────────────────────
 # Which published image tag to pull for api/dashboard/jobs.
-#   - Pin to a release (e.g. 1.4.2) in production so a new release never auto-breaks you.
-#   - "latest" = newest stable release.  "edge" = bleeding edge (last main build).
+#   - Pin to a release (e.g. 1.4.2) in production so a merge to main never auto-breaks you.
+#   - "latest" = freshest main build (moves on every merge — rolling, may include unreleased code).
+#   - "1.4.2" / "1.4" / "1" = immutable, pinned releases (published on a v* git tag).
 # Rollback = set this back to the previous version, then `... pull && up -d`.
 CIO_VERSION=latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -124,15 +124,14 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}
-          # Tag policy (stable-releases + edge):
-          #   git tag v1.4.2  -> 1.4.2, 1.4, 1, latest   (a real, stable release)
-          #   push to main     -> edge only               (latest is NEVER moved by a merge)
+          # Tag policy:
+          #   push to main    -> latest              (freshest main build; moves on every merge)
+          #   git tag v1.4.2  -> 1.4.2, 1.4, 1       (immutable, pinned release)
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
-            type=raw,value=edge,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push ${{ matrix.name }}
         uses: docker/build-push-action@v5

--- a/apps/docs/content/docs/self-hosted/docker.mdx
+++ b/apps/docs/content/docs/self-hosted/docker.mdx
@@ -112,8 +112,8 @@ The script builds and starts Postgres, Redis, MinIO (object storage), the API, t
 
 ClassroomIO publishes versioned images. `CIO_VERSION` controls which tag you run:
 
-- Pin an exact release (e.g. `1.4.2`) in production so a new release never restarts you onto changed images unattended.
-- `latest` = newest stable release. `edge` = bleeding edge (last `main` build).
+- Pin an exact release (e.g. `1.4.2`) in production so a merge to `main` never restarts you onto changed images unattended.
+- `latest` = the freshest `main` build — it moves on every merge (rolling; may include unreleased code). Version tags (`1.4.2`, `1.4`, `1`) are the immutable, pinned releases.
 
 **Pre-built images path** — bump `CIO_VERSION` in `.env`, then re-pull and recreate:
 

--- a/docker-compose.images.yaml
+++ b/docker-compose.images.yaml
@@ -8,7 +8,7 @@
 #   CIO_VERSION=1.4.2 docker compose -f docker-compose.images.yaml --env-file .env up -d
 #
 # CIO_VERSION pins the release. Use a specific version (e.g. 1.4.2) in production;
-# "latest" = newest stable release, "edge" = bleeding edge (last main build).
+# "latest" = freshest main build (moves on every merge — rolling, may include unreleased code).
 #
 # KEEP IN SYNC with docker-compose.yaml: the api/dashboard/jobs `environment`,
 # healthchecks, depends_on, and volumes must match the build-based file. The only

--- a/docker/docker-push.sh
+++ b/docker/docker-push.sh
@@ -12,8 +12,8 @@ VERSION="${VERSION:-latest}"  # Can be overridden with VERSION env var
 PUBLIC_IS_SELFHOSTED="${PUBLIC_IS_SELFHOSTED:-true}"
 PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
 
-# Only a real semver release should also move the `latest` tag — building edge/main/dev
-# must NOT clobber the stable `latest` pointer (mirrors docker-publish.yml's tag policy).
+# CI publishes `latest` from `main`. This manual/local helper only moves `latest` for a real
+# semver release, so an ad-hoc local build can't clobber the shared CI-managed `latest` pointer.
 # Use `if` (not `&&`) so the function always returns 0 even when it emits no tag — a helper
 # returning non-zero inside a $(...) argument is fragile under `set -e` / inherit_errexit.
 is_release_version() { [[ "${VERSION}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; }

--- a/docker/docker-push.sh
+++ b/docker/docker-push.sh
@@ -12,12 +12,9 @@ VERSION="${VERSION:-latest}"  # Can be overridden with VERSION env var
 PUBLIC_IS_SELFHOSTED="${PUBLIC_IS_SELFHOSTED:-true}"
 PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
 
-# CI publishes `latest` from `main`. This manual/local helper only moves `latest` for a real
-# semver release, so an ad-hoc local build can't clobber the shared CI-managed `latest` pointer.
-# Use `if` (not `&&`) so the function always returns 0 even when it emits no tag — a helper
-# returning non-zero inside a $(...) argument is fragile under `set -e` / inherit_errexit.
-is_release_version() { [[ "${VERSION}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; }
-latest_arg() { if is_release_version; then printf -- '-t %s:latest' "$1"; fi; }
+# This manual/local helper pushes ONLY the explicit ${VERSION} tag. `latest` is published
+# exclusively by CI from `main` (see .github/workflows/docker-publish.yml) — to move `latest`,
+# merge to main or re-run that workflow, never this script.
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -46,7 +43,6 @@ docker buildx build \
     --platform "${PLATFORMS}" \
     -f docker/Dockerfile.api \
     -t ${DOCKERHUB_USERNAME}/api:${VERSION} \
-    $(latest_arg ${DOCKERHUB_USERNAME}/api) \
     --push \
     .
 echo -e "${GREEN}✓ API image published successfully!${NC}"
@@ -60,7 +56,6 @@ docker buildx build \
     -f docker/Dockerfile.dashboard \
     --build-arg PUBLIC_IS_SELFHOSTED=${PUBLIC_IS_SELFHOSTED} \
     -t ${DOCKERHUB_USERNAME}/dashboard:${VERSION} \
-    $(latest_arg ${DOCKERHUB_USERNAME}/dashboard) \
     --push \
     .
 echo -e "${GREEN}✓ Dashboard image published successfully!${NC}"
@@ -72,7 +67,6 @@ docker buildx build \
     --platform "${PLATFORMS}" \
     -f docker/Dockerfile.jobs \
     -t ${DOCKERHUB_USERNAME}/jobs:${VERSION} \
-    $(latest_arg ${DOCKERHUB_USERNAME}/jobs) \
     --push \
     .
 echo -e "${GREEN}✓ Jobs image published successfully!${NC}"

--- a/docker/docker-push.sh
+++ b/docker/docker-push.sh
@@ -8,7 +8,7 @@ set -e  # Exit on error
 
 # Configuration
 DOCKERHUB_USERNAME="${DOCKERHUB_USERNAME:-classroomio}"  # Change this to your Docker Hub username
-VERSION="${VERSION:-latest}"  # Can be overridden with VERSION env var
+VERSION="${VERSION:?set VERSION to the tag to publish, e.g. VERSION=1.4.2 — this script never pushes :latest (CI owns latest from main)}"
 PUBLIC_IS_SELFHOSTED="${PUBLIC_IS_SELFHOSTED:-true}"
 PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
 

--- a/docker/docs/PUBLISHING_IMAGES.md
+++ b/docker/docs/PUBLISHING_IMAGES.md
@@ -57,8 +57,8 @@ Check your Docker Hub repository at:
 
 The workflow will automatically publish images when:
 
-1. **Push to `main`**: Publishes the **`edge`** tag only (does NOT move `latest`).
-2. **Push a version tag `vX.Y.Z`**: Publishes `X.Y.Z`, `X.Y`, `X`, and `latest`.
+1. **Push to `main`**: Publishes the **`latest`** tag (the freshest `main` build).
+2. **Push a version tag `vX.Y.Z`**: Publishes `X.Y.Z`, `X.Y`, `X` (immutable, pinned releases).
 3. **Manual trigger**: Use the Actions tab in GitHub.
 
 Every build is **boot smoke-tested** (started against ephemeral postgres + redis, healthcheck
@@ -107,7 +107,7 @@ docker pull classroomio/dashboard:latest
 
 For self-hosting with Docker Compose, see [SELF_HOST.md](SELF_HOST.md). The setup uses a single root `.env` file and `docker-compose.yaml`.
 
-## Versioning Strategy (stable-releases + edge)
+## Versioning Strategy (rolling `latest` + pinned releases)
 
 The published tags and what they mean:
 
@@ -115,17 +115,15 @@ The published tags and what they mean:
 |-----|--------------|---------|
 | `1.4.2` (exact) | a `v1.4.2` git tag | Immutable, smoke-tested release — **what production should pin** |
 | `1.4`, `1` | a `v1.4.2` git tag | Latest patch/minor of that line |
-| `latest` | a `v*` git tag only | The newest *released* version |
-| `edge` | every push to `main` | Bleeding edge; may be unstable |
+| `latest` | every push to `main` | The freshest `main` build (rolling; may include unreleased code) |
 
-The key rule: **`latest` is never moved by a routine merge to `main`** — only a deliberate release
-tag moves it. Self-hosters pin `CIO_VERSION` (see [SELF_HOST.md](SELF_HOST.md)) and upgrade on their
-own schedule.
+The key rule: **`latest` moves on every merge to `main`**, so it can change under you. Self-hosters
+pin `CIO_VERSION` (see [SELF_HOST.md](SELF_HOST.md)) and upgrade on their own schedule.
 
 ### Cutting a release
 
 Versioning is driven by git tags; the CI workflow does the rest (build multi-arch → smoke-test →
-push `X.Y.Z`/`X.Y`/`X`/`latest`).
+push `X.Y.Z`/`X.Y`/`X`). `latest` is published separately, on every merge to `main`.
 
 ```bash
 # Bump version + create the vX.Y.Z tag from the repo's changelog tooling

--- a/docker/docs/SELF_HOST.md
+++ b/docker/docs/SELF_HOST.md
@@ -44,18 +44,16 @@ From a full clone you can also use the helper: `./run-docker-full-stack.sh --ima
 
 ## Versioning & Upgrades
 
-Published images use a **stable-releases + edge** tag policy:
+Published images use a **rolling `latest` + pinned releases** tag policy:
 
 | Tag | Meaning | Use it for |
 |-----|---------|-----------|
 | `1.4.2` (exact) | An immutable, smoke-tested release | **Production — always pin this** |
 | `1.4`, `1` | Latest patch/minor of that line | Tracking a line |
-| `latest` | The newest *released* version | Trying it out |
-| `edge` | The last `main` build (may be unstable) | Testing upcoming changes |
+| `latest` | The freshest `main` build (rolling; may include unreleased code) | Trying the newest code |
 
-`latest` only moves when a real release is tagged — a routine merge to `main` publishes `edge`, never
-`latest`. **Pin `CIO_VERSION` to an exact version in production** so a new release can't break you
-unattended.
+`latest` moves on **every merge to `main`**, so it can change under you. **Pin `CIO_VERSION` to an
+exact version in production** so a merge can't break you unattended.
 
 ```bash
 # Upgrade: bump the version, pull, recreate


### PR DESCRIPTION
## What does this PR do?

Flips the Docker image tag policy so **`latest` follows `main`** instead of `edge`.

- **Before:** a merge to `main` published only `:edge`, and `:latest` moved only when a `v*` release tag was pushed (so `latest` meant "newest stable release").
- **After:** every merge to `main` publishes `:latest` (the freshest main build); the `:edge` tag is retired. Version tags (`1.4.2` / `1.4` / `1`) are unchanged — still published only from a `v*` git tag, and remain the immutable, pinned releases to use in production.

**Motivation:**
1. Simpler mental model — `latest` = freshest `main`, pinned version tags = stable.
2. Fixes a real gap: `classroomio/jobs` only ever had `:edge` (no `:latest`), which broke pull-based / one-click deploys that default to `latest`. With this change the next merge to `main` publishes `:latest` for **all three** images (api, dashboard, jobs).

Touches `.github/workflows/docker-publish.yml` plus every doc/comment that described the old policy, rewritten so nothing claims "`latest` is stable / never moves on a merge."

Fixes # (no issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [x] This change requires a documentation update

## How should this be tested?

This is CI/release behavior, so it's mostly verified post-merge:

- After this lands on `main`, the **Publish Docker Images** workflow should push `:latest` (not `:edge`) for `api`, `dashboard`, and `jobs`. Confirm on Docker Hub that jobs finally has it:
  `curl -s https://hub.docker.com/v2/repositories/classroomio/jobs/tags | grep -o '"name":"[^"]*"'` → `latest` present.
- A `v*` tag still publishes `X.Y.Z` / `X.Y` / `X` only (a tag no longer moves `latest`).
- Docs compile: `pnpm --filter @cio/docs build`; a `grep -ri '\bedge\b'` over tracked files shows no tag-policy references remain (only unrelated "edge case" / "Cloudflare edge cache" hits).
- `.github/workflows/docker-publish.yml` is valid YAML and the `tags:` block ends with `type=raw,value=latest,enable={{is_default_branch}}` and no `edge` line.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` — N/A (no app code; docs MDX compiled clean)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` (none added)
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues (no UI change)

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR — N/A
- [x] Updated the ClassroomIO Docs if changes were necessary

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes Docker image publishing so `latest` follows `main`. The main changes are:

- Publish `latest` from the main-branch workflow instead of `edge`.
- Keep version tags for release-tag builds.
- Stop the manual Docker push helper from adding `latest`.
- Update self-hosting and publishing docs for the new tag policy.

<h3>Confidence Score: 4/5</h3>

This is close, but the workflow tag guard should be fixed before merging.

- The manual Docker push helper no longer defaults to `latest`.
- The workflow can still publish `latest` from a manual run on `main`.
- That can move the rolling image tag outside the documented main-push flow.

.github/workflows/docker-publish.yml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/docker-publish.yml | Moves `latest` to default-branch builds, but the condition also matches manual runs on `main`. |
| docker/docker-push.sh | Requires an explicit `VERSION` and removes the extra `latest` tag from manual image builds. |
| .env.example | Clarifies that `latest` is a rolling main build and recommends pinning production deployments. |
| docker-compose.images.yaml | Updates image-version comments to match the rolling `latest` policy. |
| apps/docs/content/docs/self-hosted/docker.mdx | Updates self-hosted Docker docs for rolling `latest` and pinned version tags. |
| docker/docs/PUBLISHING_IMAGES.md | Updates publishing docs for the new main-driven `latest` policy. |
| docker/docs/SELF_HOST.md | Updates self-hosting version guidance for rolling `latest` and immutable releases. |

<sub>Reviews (3): Last reviewed commit: ["fix(docs): clarify VERSION variable usag..."](https://github.com/classroomio/classroomio/commit/0fcbe69a128476c03cf8b36c5f4250e4bce48015) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42322389)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->