### PR TITLE
fix(org): org logo favicon fallback and OG logo without theme tint

### DIFF
--- a/apps/api/src/utils/org-site-og.ts
+++ b/apps/api/src/utils/org-site-og.ts
@@ -146,7 +146,10 @@ function renderOrgSiteOgTemplate(input: OrgSiteOgInput): { body: string; styles:
   const labelColor = rgba(themeColor, 0.72);
   const initials = orgInitials(orgName);
 
-  const logoMarkup = input.logoUrl
+  const hasLogo = Boolean(input.logoUrl);
+  const logoWrapClass = hasLogo ? 'logo-wrap logo-wrap--image' : 'logo-wrap logo-wrap--initials';
+
+  const logoMarkup = hasLogo
     ? `<img class="logo-image" src="${escapeHtml(input.logoUrl)}" alt="" />`
     : `<span class="logo-initials" aria-hidden="true">${escapeHtml(initials)}</span>`;
 
@@ -159,7 +162,7 @@ function renderOrgSiteOgTemplate(input: OrgSiteOgInput): { body: string; styles:
   const body = `
 <div class="canvas">
   <div class="decor-circle"></div>
-  <div class="logo-wrap">${logoMarkup}</div>
+  <div class="${logoWrapClass}">${logoMarkup}</div>
   <div class="content">
     <p class="academy-label">Academy</p>
     <div class="accent-bar"></div>
@@ -214,17 +217,26 @@ body {
   width: 88px;
   height: 88px;
   border-radius: 20px;
-  background: ${themeColor};
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.logo-wrap--initials {
+  background: ${themeColor};
   box-shadow: 0 16px 40px ${rgba(themeColor, 0.28)};
 }
 
+.logo-wrap--image {
+  background: transparent;
+  box-shadow: none;
+  overflow: hidden;
+}
+
 .logo-image {
-  width: 56px;
-  height: 56px;
-  border-radius: 12px;
+  width: 88px;
+  height: 88px;
+  border-radius: 20px;
   object-fit: cover;
 }
 

--- a/apps/dashboard/src/app.html
+++ b/apps/dashboard/src/app.html
@@ -6,8 +6,6 @@
     <meta name="theme-color" content="#333333" />
 
     <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
-    <link rel="icon" type="image/png" href="/favicon.ico" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/logo-32.png" />
 
     %sveltekit.head%
   </head>

--- a/apps/dashboard/src/lib/features/app/org-site-favicon.svelte
+++ b/apps/dashboard/src/lib/features/app/org-site-favicon.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { AccountOrg } from '$features/app/types';
+  import { page } from '$app/state';
   import { getOrgFaviconHref } from '$lib/utils/functions/org-branding';
 
   interface Props {
@@ -8,11 +9,13 @@
 
   let { org }: Props = $props();
 
-  const faviconHref = $derived(getOrgFaviconHref(org));
+  const faviconHref = $derived(getOrgFaviconHref(org, page.url.origin));
 </script>
 
 <svelte:head>
   {#if faviconHref}
     <link rel="icon" href={faviconHref} />
+    <link rel="shortcut icon" href={faviconHref} />
+    <link rel="apple-touch-icon" href={faviconHref} />
   {/if}
 </svelte:head>

--- a/apps/dashboard/src/lib/utils/functions/org-branding.ts
+++ b/apps/dashboard/src/lib/utils/functions/org-branding.ts
@@ -1,15 +1,20 @@
 import type { AccountOrg } from '$features/app/types';
 
-export function getOrgFaviconHref(org: Pick<AccountOrg, 'favicon' | 'avatarUrl'> | null | undefined): string | null {
+export function getOrgFaviconHref(
+  org: Pick<AccountOrg, 'favicon' | 'avatarUrl'> | null | undefined,
+  pageOrigin?: string
+): string | null {
   const favicon = org?.favicon?.trim();
-  if (favicon) {
-    return favicon;
-  }
-
   const avatarUrl = org?.avatarUrl?.trim();
-  if (avatarUrl) {
-    return avatarUrl;
+  const rawHref = favicon || avatarUrl;
+
+  if (!rawHref) {
+    return null;
   }
 
-  return null;
+  try {
+    return new URL(rawHref, pageOrigin || undefined).href;
+  } catch {
+    return rawHref;
+  }
 }

--- a/apps/dashboard/src/routes/(org-site)/+layout.svelte
+++ b/apps/dashboard/src/routes/(org-site)/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { PageRestricted } from '$features/ui';
-  import OrgSiteFavicon from '$features/app/org-site-favicon.svelte';
   import { currentOrg } from '$lib/utils/store/org';
   import { onMount } from 'svelte';
   import { afterNavigate } from '$app/navigation';
@@ -40,8 +39,6 @@
     });
   });
 </script>
-
-<OrgSiteFavicon org={data.org} />
 
 {#if data.org?.isRestricted || $currentOrg.isRestricted}
   <PageRestricted />

--- a/apps/dashboard/src/routes/+layout.svelte
+++ b/apps/dashboard/src/routes/+layout.svelte
@@ -13,6 +13,7 @@
   import merge from 'lodash/merge';
   import { MetaTags } from 'svelte-meta-tags';
   import { ModeWatcher } from '@cio/ui/base/dark-mode';
+  import OrgSiteFavicon from '$features/app/org-site-favicon.svelte';
 
   import '../app.css';
 
@@ -61,6 +62,17 @@
     }
   });
 </script>
+
+{#if data.isOrgSite}
+  <OrgSiteFavicon org={data.org} />
+{/if}
+
+<svelte:head>
+  {#if !data.isOrgSite}
+    <link rel="icon" type="image/png" href="/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/logo-32.png" />
+  {/if}
+</svelte:head>
 
 <div>
   <ModeWatcher />

--- a/apps/dashboard/src/routes/+page.svelte
+++ b/apps/dashboard/src/routes/+page.svelte
@@ -9,7 +9,6 @@
   import { Empty } from '@cio/ui/custom/empty';
   import { SimpleLogoNav } from '@cio/ui/custom/simple-logo-nav';
   import { buildOrgLandingPageProps, normalizeLandingPageSettings } from '$features/org/utils/landing-page';
-  import OrgSiteFavicon from '$features/app/org-site-favicon.svelte';
   import { basePath } from '$lib/utils/store/app';
   import { t } from '$lib/utils/functions/translations';
   import { user } from '$lib/utils/store/user';
@@ -65,7 +64,6 @@
 </svelte:head>
 
 {#if data.isOrgSite && data.org}
-  <OrgSiteFavicon org={data.org} />
   {#if data.ThemeComponent && landingPageProps}
     <svelte:component this={data.ThemeComponent} {...landingPageProps} />
   {/if}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two org-site branding issues on public school pages:

1. **Favicon fallback** — When no custom favicon is set, the browser tab now shows the organization logo (`avatarUrl`) instead of the default ClassroomIO icon.
2. **OG image logo** — When a real logo image is present, the theme-color background is no longer applied behind it (only used for initials fallback).

## Changes

- Resolve favicon/logo URLs to absolute paths using the page origin
- Move default ClassroomIO favicon links out of `app.html` so org-site pages are not overridden
- Centralize org-site favicon in the root layout (removed duplicate instances)
- OG template: split logo container into `--image` and `--initials` variants

## Test plan

- [ ] Visit a school site without a custom favicon (e.g. `chiberry.myclassroomio.com`) — tab icon should show the org logo
- [ ] Preview OG image — logo should be visible without theme-color wash
- [ ] Org without logo should still show themed initials in OG image
- [ ] Non-org pages (dashboard, login) should still use ClassroomIO favicon
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2632-e717-7e86-a875-54e91ba4b856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2632-e717-7e86-a875-54e91ba4b856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates org-site favicon and OG logo handling.

- Moves default favicon links from `app.html` into the root layout.
- Adds org-specific favicon, shortcut icon, and apple-touch-icon links.
- Resolves org favicon URLs against the current page origin.
- Splits OG logo styling between image logos and initials fallback.

<h3>Confidence Score: 4/5</h3>

The changed favicon path has a contained fallback bug for orgs without branding.

- Org sites with no favicon or avatar URL can lose all favicon links.
- OG previews can lose visible branding when a stored logo image cannot render cleanly.
- No security issue was found in the changed code.

apps/dashboard/src/routes/+layout.svelte and apps/api/src/utils/org-site-og.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/routes/+layout.svelte | Moves favicon ownership into the root layout, but the org-site branch lacks a default fallback when no org favicon URL exists. |
| apps/dashboard/src/lib/features/app/org-site-favicon.svelte | Adds org-specific favicon link variants and uses the page origin for URL resolution. |
| apps/dashboard/src/lib/utils/functions/org-branding.ts | Centralizes favicon selection and absolute URL normalization. |
| apps/api/src/utils/org-site-og.ts | Separates OG logo image styling from initials styling, with a possible blank-logo fallback issue for broken or transparent images. |
| apps/dashboard/src/app.html | Removes global default favicon links so route layouts control favicon output. |
| apps/dashboard/src/routes/(org-site)/+layout.svelte | Removes duplicate org favicon rendering from the org-site layout. |
| apps/dashboard/src/routes/+page.svelte | Removes duplicate org favicon rendering from the root page. |

<sub>Reviews (1): Last reviewed commit: ["fix(org): show org logo for favicon and ..."](https://github.com/classroomio/classroomio/commit/ca6556bb329e1d9418c58f128211bc5df082a771) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42584440)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->