### PR TITLE
fix(sidebar): scope elevated mobile z-index to course sidebar

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte
@@ -112,7 +112,7 @@
 {#if !isOrgLoaded}
   <SidebarSkeleton />
 {:else}
-  <Sidebar.Root collapsible="icon" class="ui:z-150!">
+  <Sidebar.Root collapsible="icon" class="ui:z-150!" mobileOverlayClass="ui:z-150!">
     <Sidebar.Header>
       <CourseSidebarLogo />
     </Sidebar.Header>

--- a/packages/ui/src/base/sidebar/sidebar.svelte
+++ b/packages/ui/src/base/sidebar/sidebar.svelte
@@ -11,12 +11,14 @@
     variant = 'sidebar',
     collapsible = 'offcanvas',
     class: className,
+    mobileOverlayClass,
     children,
     ...restProps
   }: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
     side?: 'left' | 'right';
     variant?: 'sidebar' | 'floating' | 'inset';
     collapsible?: 'offcanvas' | 'icon' | 'none';
+    mobileOverlayClass?: string;
   } = $props();
 
   const sidebar = useSidebar();
@@ -39,9 +41,9 @@
       data-sidebar="sidebar"
       data-slot="sidebar"
       data-mobile="true"
-      overlayClass="ui:z-150!"
+      overlayClass={mobileOverlayClass}
       class={cn(
-        'ui:bg-sidebar ui:text-sidebar-foreground ui:w-(--sidebar-width) ui:z-150! ui:p-0 ui:[&>button]:hidden',
+        'ui:bg-sidebar ui:text-sidebar-foreground ui:w-(--sidebar-width) ui:p-0 ui:[&>button]:hidden',
         className
       )}
       style="--sidebar-width: {SIDEBAR_WIDTH_MOBILE};"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The merged mobile sidebar fix raised **all** sidebars to `z-150`, which blocked LMS footer dropdown menus (logout, etc.) from opening above the sheet.

This scopes the elevated stacking to the **course sidebar only**:

- `Sidebar.Root` no longer hardcodes `z-150` on mobile
- Added optional `mobileOverlayClass` prop for per-sidebar overlay styling
- `CourseSidebar` opts in with `mobileOverlayClass="ui:z-150!"` and its existing `class="ui:z-150!"` (applies to mobile sheet content + desktop container)

LMS, org, and cohort sidebars keep the default sheet `z-50`.

## Test plan

- [ ] **Course (mobile):** open content sidebar on a lesson/exercise — sidebar should still sit above the sticky page header
- [ ] **LMS (mobile):** open sidebar footer menu — logout and other items should be clickable
- [ ] **Desktop:** course sidebar behavior unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4a6e-6f06-7ffc-ba94-75b7e8c00a97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4a6e-6f06-7ffc-ba94-75b7e8c00a97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes the previously blanket `z-150` mobile z-index to the course sidebar only, fixing a regression where the elevated stacking blocked LMS sidebar footer dropdowns on mobile.

- `Sidebar.Root` gains an optional `mobileOverlayClass` prop so each sidebar can independently control the mobile sheet overlay's z-index, while the default reverts to `z-50`.
- `CourseSidebar` opts in with both `class="ui:z-150!"` (sheet content + desktop container) and `mobileOverlayClass="ui:z-150!"` (overlay), preserving its above-header stacking on the course pages without affecting other sidebar instances.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is tightly scoped and restores correct stacking context for all non-course sidebars.

Both changed files make minimal, targeted adjustments. The new mobileOverlayClass prop correctly threads through Sheet.Content → SheetOverlay, the course sidebar explicitly opts in for both the overlay and the sheet content, and all other sidebars simply fall back to the existing z-50 default. Desktop behavior is unchanged. No new logic paths or edge cases are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/base/sidebar/sidebar.svelte | Introduces optional mobileOverlayClass prop; removes hardcoded z-150 from mobile sheet overlay and content, restoring the default z-50 for all non-course sidebars. |
| apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte | Adds mobileOverlayClass="ui:z-150!" to opt the course sidebar into the elevated overlay z-index; existing class="ui:z-150!" already covers sheet content and desktop container. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sidebar.Root rendered] --> B{isMobile?}
    B -- Yes --> C[Sheet.Root / Sheet.Content]
    C --> D{mobileOverlayClass provided?}
    D -- Yes\ncourse sidebar --> E[SheetOverlay z-150!\nSheet.Content z-150!]
    D -- No\nLMS / org / cohort --> F[SheetOverlay z-50\nSheet.Content z-50]
    B -- No --> G[Desktop container div]
    G --> H{className provided?}
    H -- Yes\ncourse sidebar --> I[Container z-150!\noverrides default z-100]
    H -- No --> J[Container z-100 default]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Sidebar.Root rendered] --> B{isMobile?}
    B -- Yes --> C[Sheet.Root / Sheet.Content]
    C --> D{mobileOverlayClass provided?}
    D -- Yes\ncourse sidebar --> E[SheetOverlay z-150!\nSheet.Content z-150!]
    D -- No\nLMS / org / cohort --> F[SheetOverlay z-50\nSheet.Content z-50]
    B -- No --> G[Desktop container div]
    G --> H{className provided?}
    H -- Yes\ncourse sidebar --> I[Container z-150!\noverrides default z-100]
    H -- No --> J[Container z-100 default]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(sidebar): scope elevated mobile z-in..."](https://github.com/classroomio/classroomio/commit/b88872512502b5f9dcd3b27742f88e0640855201) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43241916)</sub>

<!-- /greptile_comment -->