### PR TITLE
fix(dashboard): stop enroll effect loop and duplicate verify emails

### DIFF
--- a/apps/dashboard/src/routes/(org-site)/course/[slug]/enroll/+page.svelte
+++ b/apps/dashboard/src/routes/(org-site)/course/[slug]/enroll/+page.svelte
@@ -18,7 +18,8 @@
 
   let loading = $state(false);
   let enrollmentInFlight = $state(false);
-  let enrollmentAttemptKey = $state('');
+  let enrollmentSucceeded = $state(false);
+  let verificationEmailSent = $state(false);
   let enrolledPendingVerification = $state(false);
 
   const session = authClient.useSession();
@@ -87,7 +88,7 @@
   }
 
   async function completeEnrollment() {
-    if (!data.course?.id || enrollmentInFlight) {
+    if (!data.course?.id || enrollmentInFlight || enrollmentSucceeded) {
       return;
     }
 
@@ -105,6 +106,8 @@
         return;
       }
 
+      enrollmentSucceeded = true;
+
       const studentId = $profile.id || sessionUser?.id || '';
       const studentEmail = $profile.email || sessionUser?.email || '';
 
@@ -117,7 +120,12 @@
 
       if (!isEmailVerified) {
         enrolledPendingVerification = true;
-        void sendVerificationEmail();
+
+        if (!verificationEmailSent) {
+          verificationEmailSent = true;
+          void sendVerificationEmail();
+        }
+
         return;
       }
 
@@ -127,7 +135,6 @@
       enrollmentInFlight = false;
       if (!navigatingAway) {
         loading = false;
-        enrollmentAttemptKey = '';
       }
     }
   }
@@ -163,7 +170,7 @@
   }
 
   $effect(() => {
-    if (!sessionReady || !isLoggedIn || !canJoinCourse || enrollmentInFlight || loading) {
+    if (!sessionReady || !isLoggedIn || !canJoinCourse || enrollmentInFlight || loading || enrollmentSucceeded) {
       return;
     }
 
@@ -171,12 +178,6 @@
       return;
     }
 
-    const attemptKey = `${sessionUser?.id ?? ''}:${data.course?.id ?? ''}`;
-    if (enrollmentAttemptKey === attemptKey) {
-      return;
-    }
-
-    enrollmentAttemptKey = attemptKey;
     void completeEnrollment();
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #718 (merged). The auto-enroll `$effect` on the org-site enroll page was retriggering enroll API calls and `sendVerificationEmail()` on every reactive tick for unverified users, flooding them with duplicate verification emails and repeatedly re-adding them to the course.

## Root cause

`completeEnrollment()` reset `enrollmentAttemptKey = ''` in its `finally` block after a successful (but not-yet-verified) enrollment. That cleared the effect's guard, so the effect immediately fired again:

1. `sessionReady`, `isLoggedIn`, `canJoinCourse` all still true
2. `enrollmentInFlight` back to `false`
3. `enrollmentAttemptKey` no longer matches → effect re-runs → `completeEnrollment()` called again

Each iteration re-called `courseApi.enroll(...)` and `sendVerificationEmail()`, producing the infinite email loop and repeated enroll attempts.

## Fix

- Replace the per-key guard with a persistent `enrollmentSucceeded` flag; the effect never re-runs `completeEnrollment()` once enrollment succeeds for this page load.
- Add `verificationEmailSent` so the auto-send fires at most once; the resend button still works normally (unaffected).

## Testing

- ✅ `pnpm format:check`
- Traced the effect re-entry logic against the `enrollmentAttemptKey` reset in `finally` — confirmed the old code re-armed the effect after every completed run.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-627d2c91-c091-4912-bb15-45359d3e8b6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-627d2c91-c091-4912-bb15-45359d3e8b6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an infinite effect loop on the enroll page where resetting `enrollmentAttemptKey` in the `finally` block re-armed the Svelte `$effect`, causing repeated `courseApi.enroll()` calls and duplicate verification emails for unverified users on every reactive tick.

- **Root cause eliminated**: the `enrollmentAttemptKey` (reset in `finally`) is replaced by `enrollmentSucceeded`, a persistent boolean set immediately after a successful API response; both the `$effect` and `completeEnrollment()` gate on it, so no second enrollment can run in the same page load.
- **Duplicate email guard**: `verificationEmailSent` is set to `true` before the auto-send fires; the manual resend button calls `sendVerificationEmail()` directly and remains unaffected.
- **Error path unchanged**: a failed API call (`!result?.data`) still leaves `enrollmentSucceeded = false`, so a transient failure allows the effect to retry — this was identical behaviour before and is not worsened by the PR.

<h3>Confidence Score: 5/5</h3>

Safe to merge — focused one-file fix that eliminates an observable infinite-loop bug without touching shared state, API contracts, or unrelated UI paths.

Both guards (enrollmentSucceeded in the effect and inside completeEnrollment) are set at the correct moment, and the finally block no longer clears any guard the effect depends on, fully closing the re-entry path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/routes/(org-site)/course/[slug]/enroll/+page.svelte | Replaces the buggy per-key effect guard (enrollmentAttemptKey, reset in finally) with two persistent boolean flags (enrollmentSucceeded, verificationEmailSent) that prevent re-enrollment and duplicate verification emails after the first successful API call; fix is logically correct and the resend button path is unaffected. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["`$effect fires`"] --> B{enrollmentInFlight or loading or enrollmentSucceeded?}
    B -- yes --> Z[Return early]
    B -- no --> C{appInitApi ready?}
    C -- no --> Z
    C -- yes --> D[completeEnrollment]
    D --> E{enrollmentSucceeded?}
    E -- yes --> Z
    E -- no --> F[enrollmentInFlight = true]
    F --> G[courseApi.enroll]
    G --> H{result.data?}
    H -- falsy --> I[snackbar error]
    I --> K
    H -- success --> J[enrollmentSucceeded = true]
    J --> L{isEmailVerified?}
    L -- yes --> M[navigatingAway = true goto /lms]
    M --> K
    L -- no --> N[enrolledPendingVerification = true]
    N --> O{verificationEmailSent?}
    O -- yes --> P[return]
    P --> K
    O -- no --> Q[verificationEmailSent = true sendVerificationEmail]
    Q --> K
    K[finally: enrollmentInFlight = false]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["`$effect fires`"] --> B{enrollmentInFlight or loading or enrollmentSucceeded?}
    B -- yes --> Z[Return early]
    B -- no --> C{appInitApi ready?}
    C -- no --> Z
    C -- yes --> D[completeEnrollment]
    D --> E{enrollmentSucceeded?}
    E -- yes --> Z
    E -- no --> F[enrollmentInFlight = true]
    F --> G[courseApi.enroll]
    G --> H{result.data?}
    H -- falsy --> I[snackbar error]
    I --> K
    H -- success --> J[enrollmentSucceeded = true]
    J --> L{isEmailVerified?}
    L -- yes --> M[navigatingAway = true goto /lms]
    M --> K
    L -- no --> N[enrolledPendingVerification = true]
    N --> O{verificationEmailSent?}
    O -- yes --> P[return]
    P --> K
    O -- no --> Q[verificationEmailSent = true sendVerificationEmail]
    Q --> K
    K[finally: enrollmentInFlight = false]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): stop enroll effect loop ..."](https://github.com/classroomio/classroomio/commit/e4406481d6772577e7daa03295a98a2898f0027e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43318185)</sub>

<!-- /greptile_comment -->