### PR TITLE
fix(auth): sync profile email verification with auth user

### DIFF
--- a/apps/api/src/services/account/profile.ts
+++ b/apps/api/src/services/account/profile.ts
@@ -5,7 +5,12 @@ import {
   getOrganizationByProfileId,
   hasOrgMemberByProfileIdOrEmail
 } from '@cio/db/queries/organization';
-import { getProfileByEmail, getProfileById, updateProfile } from '@cio/db/queries/auth';
+import {
+  getProfileByEmail,
+  getProfileById,
+  syncProfileEmailVerificationFromAuthUser,
+  updateProfile
+} from '@cio/db/queries/auth';
 
 import type { OrganizationWithMemberAndPlans } from '@cio/db/queries/organization/types';
 import { ROLE } from '@cio/utils/constants';
@@ -37,6 +42,8 @@ export async function getAccountData(userId: string): Promise<GetAccountDataResu
   if (!profile) {
     throw new AppError(`Account not found for user ID: ${userId}`, ErrorCodes.ACCOUNT_NOT_FOUND, 404);
   }
+
+  profile = (await syncProfileEmailVerificationFromAuthUser(userId)) ?? profile;
 
   // Self-hosted: auto-add user as student to the single org if they are not a member.
   // Skip if they already have membership (by profileId) or a pending invite (by email).

--- a/apps/dashboard/src/lib/features/onboarding/components/verify-email-modal.svelte
+++ b/apps/dashboard/src/lib/features/onboarding/components/verify-email-modal.svelte
@@ -6,6 +6,7 @@
   import { currentOrg } from '$lib/utils/store/org';
   import { profile } from '$lib/utils/store/user';
   import { authClient } from '$lib/utils/services/auth/client';
+  import { classroomio } from '$lib/utils/services/api';
   import { globalStore } from '$lib/utils/store/app';
   import { page } from '$app/state';
   import { onMount, onDestroy } from 'svelte';
@@ -22,9 +23,33 @@
   let interval;
   let countDown = $state(WAIT_SEC);
 
-  const open = $derived(Boolean(!$profile.isEmailVerified && !!$profile.id && !!$currentOrg.id));
+  const session = authClient.useSession();
+  const sessionUser = $derived($session.data?.user ?? null);
+  const isEmailVerified = $derived(Boolean($profile.isEmailVerified || sessionUser?.emailVerified));
+  const open = $derived(Boolean(!isEmailVerified && !!$profile.id && !!$currentOrg.id));
 
   let domProtectionCleanup: ReturnType<typeof setupDOMProtection> | undefined;
+
+  async function syncProfileFromAccount() {
+    const response = await classroomio.account.$get();
+    if (!response.ok) {
+      return;
+    }
+
+    const data = await response.json();
+    if (data.success && data.profile) {
+      profile.set(data.profile);
+    }
+  }
+
+  function isAlreadyVerifiedError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+      return false;
+    }
+
+    const maybeError = error as { code?: string; message?: string };
+    return maybeError.code === 'EMAIL_IS_ALREADY_VERIFIED' || maybeError.message === 'Email is already verified';
+  }
 
   const sendVerificationCode = async () => {
     if (!$profile.email) {
@@ -45,16 +70,30 @@
         callbackURL.searchParams.set('welcomePopup', 'true');
       }
 
-      await authClient.sendVerificationEmail({
+      const result = await authClient.sendVerificationEmail({
         email: $profile.email,
         callbackURL: callbackURL.toString()
       });
 
+      if (result?.error && isAlreadyVerifiedError(result.error)) {
+        await syncProfileFromAccount();
+        return;
+      }
+
       isSent = true;
     } catch (error) {
+      if (isAlreadyVerifiedError(error)) {
+        await syncProfileFromAccount();
+        return;
+      }
+
       snackbar.error('verify_email_modal.snackbar.error');
     } finally {
       loading = false;
+    }
+
+    if (!isSent) {
+      return;
     }
 
     interval = setInterval(() => {
@@ -70,7 +109,7 @@
 
   onMount(() => {
     if (browser && $profile.id) {
-      domProtectionCleanup = setupDOMProtection(() => $profile.isEmailVerified ?? false);
+      domProtectionCleanup = setupDOMProtection(() => isEmailVerified);
     }
   });
 
@@ -82,9 +121,9 @@
   });
 
   $effect(() => {
-    if (browser) updateBodyClass($profile.isEmailVerified ?? false);
+    if (browser) updateBodyClass(isEmailVerified);
 
-    if (browser && !$profile.isEmailVerified && $profile.id) {
+    if (browser && !isEmailVerified && $profile.id) {
       console.warn(
         '%c🔒 SECURITY WARNING: Email verification required',
         'color: red; font-weight: bold; font-size: 16px;',
@@ -92,6 +131,14 @@
         '\nAttempting to bypass this protection is monitored and logged.'
       );
     }
+  });
+
+  $effect(() => {
+    if (!browser || !$profile.id || $profile.isEmailVerified || !sessionUser?.emailVerified) {
+      return;
+    }
+
+    void syncProfileFromAccount();
   });
 
   $effect(() => {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "release": "standard-version",
     "db:reset": "pnpm --filter @cio/db db:reset",
     "db:studio": "pnpm --filter @cio/db db:studio",
+    "db:backfill-profile-email-verification": "pnpm --filter @cio/db db:backfill-profile-email-verification",
     "dashboard:dev": "pnpm concurrently -n dashboard,ui -c blue,yellow \"pnpm --filter=@cio/dashboard run dev\" \"pnpm --filter=@cio/ui run dev\"",
     "api:dev": "pnpm concurrently -n api,jobs -c blue,yellow \"pnpm --filter=@cio/api run dev\" \"pnpm --filter=@cio/jobs-worker run dev\"",
     "jobs:dev": "pnpm --filter=@cio/jobs-worker run dev",

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -66,6 +66,26 @@ Requires `DATABASE_URL` or `PRIVATE_DATABASE_URL` in the environment. The script
 cp .env.example .env   # then set DATABASE_URL for your DB
 ```
 
+#### db:backfill-profile-email-verification
+
+Repairs stale `profile.is_email_verified` rows where the auth user is already verified (`user.email_verified = true`) or has a linked OAuth/SSO account, but the profile flag was never synced. Use after the auth/profile verification mismatch fix, or when users are blocked by the verify-email modal while `send-verification-email` returns `EMAIL_IS_ALREADY_VERIFIED`.
+
+Dry run (lists affected count and a sample; makes no changes):
+
+```bash
+pnpm db:backfill-profile-email-verification
+# or from repo root:
+pnpm --filter @cio/db db:backfill-profile-email-verification
+```
+
+Apply updates:
+
+```bash
+pnpm db:backfill-profile-email-verification -- --execute
+```
+
+The script prints how many profiles were updated and verifies zero mismatches remain.
+
 ## Seeding
 
 The seed script populates the database with demo data for local development. It is idempotent — running it multiple times is safe; existing records are skipped.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -67,6 +67,7 @@
     "db:rewrite-media-host": "tsx src/scripts/rewrite-media-host.ts",
     "db:login-link": "tsx src/scripts/generate-login-link.ts",
     "db:sync-orphaned-profiles": "tsx src/scripts/sync-orphaned-profiles.ts",
+    "db:backfill-profile-email-verification": "tsx src/scripts/backfill-profile-email-verification.ts",
     "move-users": "tsx src/scripts/supabase-to-betterauth.ts",
     "pull": "drizzle-kit pull --config drizzle.config.ts",
     "generate-types": "tsx scripts/generate-types.ts && pnpm format",

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -18,6 +18,7 @@ import { sso } from '@better-auth/sso';
 import { syncUserWithProfile } from './auth/hooks/sync-user';
 import { tokenExchange } from './auth/plugins/token-exchange';
 import { trackLoginHook } from './auth/hooks/track-login';
+import { syncProfileEmailVerificationFromAuthUser } from './queries/auth/profile';
 
 export { mintLoginLinkToken } from './auth/login-link';
 
@@ -112,11 +113,13 @@ export const auth: ReturnType<typeof betterAuth> = betterAuth({
       create: {
         after: async (session) => {
           await trackLoginHook(session);
+          await syncProfileEmailVerificationFromAuthUser(session.userId);
         }
       },
       update: {
         after: async (session) => {
           await trackLoginHook(session);
+          await syncProfileEmailVerificationFromAuthUser(session.userId);
         }
       }
     }

--- a/packages/db/src/auth/hooks/create-profile.ts
+++ b/packages/db/src/auth/hooks/create-profile.ts
@@ -1,23 +1,12 @@
 import * as schema from '@db/schema';
 
-import { and, eq, ne } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 
 import { User } from 'better-auth';
 import { db } from '@db/drizzle';
+import { hasVerifiedEmailProvider } from '@db/queries/auth/profile';
 import { getOrganizationCount } from '@db/queries/organization';
 import { ssoProvisioningHook } from './sso-provisioning';
-
-/**
- * True if the user has any non-credential account (OAuth/SSO). Those providers verify email.
- */
-export async function hasVerifiedEmailProvider(userId: string): Promise<boolean> {
-  const accounts = await db
-    .select({ providerId: schema.account.providerId })
-    .from(schema.account)
-    .where(and(eq(schema.account.userId, userId), ne(schema.account.providerId, 'credential')))
-    .limit(1);
-  return accounts.length > 0;
-}
 
 /**
  * True when this is a first-time signup on a self-hosted instance (no orgs exist yet).
@@ -59,6 +48,13 @@ export const createProfileHook = async (user: User, _request?: Request) => {
   }
 
   if (existingProfile.length) {
+    if (!existingProfile[0].isEmailVerified && isEmailVerified) {
+      await db
+        .update(schema.profile)
+        .set({ isEmailVerified: true, verifiedAt: new Date().toISOString() })
+        .where(eq(schema.profile.id, user.id));
+    }
+
     return;
   }
 

--- a/packages/db/src/auth/hooks/create-profile.ts
+++ b/packages/db/src/auth/hooks/create-profile.ts
@@ -49,6 +49,7 @@ export const createProfileHook = async (user: User, _request?: Request) => {
 
   if (existingProfile.length) {
     if (!existingProfile[0].isEmailVerified && isEmailVerified) {
+      await db.update(schema.user).set({ emailVerified: true }).where(eq(schema.user.id, user.id));
       await db
         .update(schema.profile)
         .set({ isEmailVerified: true, verifiedAt: new Date().toISOString() })

--- a/packages/db/src/auth/hooks/sync-user.ts
+++ b/packages/db/src/auth/hooks/sync-user.ts
@@ -1,9 +1,5 @@
-import * as schema from '@db/schema';
-
 import { User } from 'better-auth';
-import { db } from '@db/drizzle';
-import { eq } from 'drizzle-orm';
-import { hasVerifiedEmailProvider } from './create-profile';
+import { syncProfileEmailVerificationFromAuthUser } from '@db/queries/auth/profile';
 
 export const syncUserWithProfile = async (user: User) => {
   console.log('[auth] syncUserWithProfile: running', { userId: user?.id });
@@ -13,15 +9,8 @@ export const syncUserWithProfile = async (user: User) => {
   }
 
   try {
-    const isEmailVerified = user.emailVerified || (await hasVerifiedEmailProvider(user.id));
-    await db
-      .update(schema.profile)
-      .set({
-        email: user.email,
-        isEmailVerified
-      })
-      .where(eq(schema.profile.id, user.id));
+    await syncProfileEmailVerificationFromAuthUser(user.id);
   } catch (error) {
-    console.error('Error marking profile as verified:', error);
+    console.error('Error syncing profile email verification:', error);
   }
 };

--- a/packages/db/src/queries/auth/profile.ts
+++ b/packages/db/src/queries/auth/profile.ts
@@ -2,7 +2,78 @@ import * as schema from '@db/schema';
 
 import type { TProfile } from '@db/types';
 import { db, type DbOrTxClient } from '@db/drizzle';
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, ne } from 'drizzle-orm';
+
+/**
+ * True when the auth user has any non-credential account (OAuth/SSO). Those providers verify email.
+ */
+export async function hasVerifiedEmailProvider(userId: string, dbClient: DbOrTxClient = db): Promise<boolean> {
+  const accounts = await dbClient
+    .select({ providerId: schema.account.providerId })
+    .from(schema.account)
+    .where(and(eq(schema.account.userId, userId), ne(schema.account.providerId, 'credential')))
+    .limit(1);
+
+  return accounts.length > 0;
+}
+
+async function resolveAuthUserEmailVerified(
+  userId: string,
+  emailVerified: boolean,
+  dbClient: DbOrTxClient = db
+): Promise<boolean> {
+  if (emailVerified) {
+    return true;
+  }
+
+  return hasVerifiedEmailProvider(userId, dbClient);
+}
+
+/**
+ * Keeps profile.is_email_verified in sync with auth user + linked OAuth/SSO accounts.
+ * Repairs legacy rows where user.email_verified is true but profile.is_email_verified is false.
+ */
+export async function syncProfileEmailVerificationFromAuthUser(userId: string, dbClient: DbOrTxClient = db) {
+  try {
+    const [user] = await dbClient.select().from(schema.user).where(eq(schema.user.id, userId)).limit(1);
+    if (!user) {
+      return null;
+    }
+
+    const [profile] = await dbClient.select().from(schema.profile).where(eq(schema.profile.id, userId)).limit(1);
+    if (!profile) {
+      return null;
+    }
+
+    const isEmailVerified = await resolveAuthUserEmailVerified(userId, user.emailVerified, dbClient);
+    const emailChanged = profile.email !== user.email;
+    const verificationChanged = profile.isEmailVerified !== isEmailVerified;
+
+    if (!emailChanged && !verificationChanged) {
+      return profile;
+    }
+
+    const patch: Partial<TProfile> = {
+      email: user.email,
+      isEmailVerified
+    };
+
+    if (isEmailVerified && !profile.isEmailVerified) {
+      patch.verifiedAt = new Date().toISOString();
+    }
+
+    const [updatedProfile] = await dbClient
+      .update(schema.profile)
+      .set(patch)
+      .where(eq(schema.profile.id, userId))
+      .returning();
+
+    return updatedProfile ?? profile;
+  } catch (error) {
+    console.error('syncProfileEmailVerificationFromAuthUser error:', error);
+    throw new Error('Failed to sync profile email verification');
+  }
+}
 
 export const getProfileById = async (id: string) => {
   const [profile] = await db.select().from(schema.profile).where(eq(schema.profile.id, id)).limit(1);

--- a/packages/db/src/queries/auth/profile.ts
+++ b/packages/db/src/queries/auth/profile.ts
@@ -31,8 +31,9 @@ async function resolveAuthUserEmailVerified(
 
 /**
  * Keeps profile.is_email_verified in sync with auth user + linked OAuth/SSO accounts.
- * Repairs legacy rows where user.email_verified is true but profile.is_email_verified is false.
- * Never demotes profile.is_email_verified — some flows verify the profile before user.email_verified is set.
+ * Repairs legacy rows where user.email_verified is true but profile.is_email_verified is false,
+ * and promotes user.email_verified when profile is already verified (e.g. self-hosted bootstrap).
+ * Never demotes profile.is_email_verified.
  */
 export async function syncProfileEmailVerificationFromAuthUser(userId: string, dbClient: DbOrTxClient = db) {
   try {
@@ -51,10 +52,15 @@ export async function syncProfileEmailVerificationFromAuthUser(userId: string, d
     // self-hosted first signup, invites, or other flows before user.email_verified catches up.
     const isEmailVerified = profile.isEmailVerified || authSaysVerified;
     const emailChanged = profile.email !== user.email;
-    const verificationChanged = profile.isEmailVerified !== isEmailVerified;
+    const profileNeedsVerification = isEmailVerified && !profile.isEmailVerified;
+    const userNeedsVerification = isEmailVerified && !user.emailVerified;
 
-    if (!emailChanged && !verificationChanged) {
+    if (!emailChanged && !profileNeedsVerification && !userNeedsVerification) {
       return profile;
+    }
+
+    if (userNeedsVerification) {
+      await dbClient.update(schema.user).set({ emailVerified: true }).where(eq(schema.user.id, userId));
     }
 
     const patch: Partial<TProfile> = {
@@ -62,8 +68,12 @@ export async function syncProfileEmailVerificationFromAuthUser(userId: string, d
       isEmailVerified
     };
 
-    if (isEmailVerified && !profile.isEmailVerified) {
+    if (profileNeedsVerification) {
       patch.verifiedAt = new Date().toISOString();
+    }
+
+    if (!emailChanged && !profileNeedsVerification) {
+      return { ...profile, isEmailVerified: true };
     }
 
     const [updatedProfile] = await dbClient
@@ -72,7 +82,7 @@ export async function syncProfileEmailVerificationFromAuthUser(userId: string, d
       .where(eq(schema.profile.id, userId))
       .returning();
 
-    return updatedProfile ?? profile;
+    return updatedProfile ?? { ...profile, isEmailVerified: true };
   } catch (error) {
     console.error('syncProfileEmailVerificationFromAuthUser error:', error);
     throw new Error('Failed to sync profile email verification');

--- a/packages/db/src/queries/auth/profile.ts
+++ b/packages/db/src/queries/auth/profile.ts
@@ -32,6 +32,7 @@ async function resolveAuthUserEmailVerified(
 /**
  * Keeps profile.is_email_verified in sync with auth user + linked OAuth/SSO accounts.
  * Repairs legacy rows where user.email_verified is true but profile.is_email_verified is false.
+ * Never demotes profile.is_email_verified — some flows verify the profile before user.email_verified is set.
  */
 export async function syncProfileEmailVerificationFromAuthUser(userId: string, dbClient: DbOrTxClient = db) {
   try {
@@ -45,7 +46,10 @@ export async function syncProfileEmailVerificationFromAuthUser(userId: string, d
       return null;
     }
 
-    const isEmailVerified = await resolveAuthUserEmailVerified(userId, user.emailVerified, dbClient);
+    const authSaysVerified = await resolveAuthUserEmailVerified(userId, user.emailVerified, dbClient);
+    // Only promote verification — never demote. Profile can be verified via
+    // self-hosted first signup, invites, or other flows before user.email_verified catches up.
+    const isEmailVerified = profile.isEmailVerified || authSaysVerified;
     const emailChanged = profile.email !== user.email;
     const verificationChanged = profile.isEmailVerified !== isEmailVerified;
 

--- a/packages/db/src/scripts/backfill-profile-email-verification.ts
+++ b/packages/db/src/scripts/backfill-profile-email-verification.ts
@@ -1,0 +1,103 @@
+/**
+ * Backfills profile.is_email_verified for users already verified in auth
+ * (user.email_verified or a linked OAuth/SSO account) but stale on profile.
+ *
+ * Usage:
+ *   pnpm --filter @cio/db db:backfill-profile-email-verification           # dry run (default)
+ *   pnpm --filter @cio/db db:backfill-profile-email-verification --execute # apply updates
+ */
+import 'dotenv/config';
+
+import postgres from 'postgres';
+
+const connectionString = process.env.DATABASE_URL ?? process.env.PRIVATE_DATABASE_URL ?? '';
+const shouldExecute = process.argv.includes('--execute');
+
+if (!connectionString) {
+  console.error('DATABASE_URL or PRIVATE_DATABASE_URL environment variable is required');
+  process.exit(1);
+}
+
+const AFFECTED_PROFILES_SQL = `
+  SELECT
+    p.id,
+    u.email,
+    u.email_verified AS user_email_verified,
+    p.is_email_verified AS profile_is_email_verified
+  FROM profile p
+  JOIN "user" u ON u.id = p.id
+  WHERE COALESCE(p.is_email_verified, false) = false
+    AND (
+      u.email_verified = true
+      OR EXISTS (
+        SELECT 1
+        FROM account a
+        WHERE a.user_id = u.id
+          AND a.provider_id <> 'credential'
+      )
+    )
+`;
+
+async function main() {
+  const sql = postgres(connectionString);
+
+  try {
+    const affected = await sql.unsafe(AFFECTED_PROFILES_SQL);
+    console.log(`Found ${affected.length} profile(s) to backfill.`);
+
+    if (affected.length === 0) {
+      console.log('Nothing to do.');
+      return;
+    }
+
+    if (!shouldExecute) {
+      console.log('Dry run only. Re-run with --execute to apply updates.');
+      console.log('Sample (up to 10):');
+      for (const row of affected.slice(0, 10)) {
+        console.log(`  ${row.id}  ${row.email}  user=${row.user_email_verified}  profile=${row.profile_is_email_verified}`);
+      }
+      return;
+    }
+
+    const updated = await sql`
+      UPDATE profile p
+      SET
+        is_email_verified = true,
+        verified_at = COALESCE(p.verified_at, NOW()),
+        updated_at = NOW()
+      FROM "user" u
+      WHERE p.id = u.id
+        AND COALESCE(p.is_email_verified, false) = false
+        AND (
+          u.email_verified = true
+          OR EXISTS (
+            SELECT 1
+            FROM account a
+            WHERE a.user_id = u.id
+              AND a.provider_id <> 'credential'
+          )
+        )
+      RETURNING p.id, p.email
+    `;
+
+    const remaining = await sql.unsafe(`SELECT COUNT(*)::int AS count FROM (${AFFECTED_PROFILES_SQL}) AS affected`);
+    const remainingCount = remaining[0]?.count ?? 0;
+
+    console.log(`Updated ${updated.length} profile(s).`);
+    console.log(`Remaining mismatches: ${remainingCount}`);
+
+    if (remainingCount > 0) {
+      console.warn('Some rows were not updated — inspect manually before retrying.');
+      process.exit(1);
+    }
+
+    console.log('Backfill complete.');
+  } catch (error) {
+    console.error('backfill-profile-email-verification error:', error);
+    throw error;
+  } finally {
+    await sql.end();
+  }
+}
+
+main();

--- a/packages/db/src/scripts/backfill-profile-email-verification.ts
+++ b/packages/db/src/scripts/backfill-profile-email-verification.ts
@@ -3,8 +3,8 @@
  * (user.email_verified or a linked OAuth/SSO account) but stale on profile.
  *
  * Usage:
- *   pnpm --filter @cio/db db:backfill-profile-email-verification           # dry run (default)
- *   pnpm --filter @cio/db db:backfill-profile-email-verification --execute # apply updates
+ *   pnpm db:backfill-profile-email-verification           # dry run (default)
+ *   pnpm db:backfill-profile-email-verification -- --execute # apply updates
  */
 import 'dotenv/config';
 
@@ -54,7 +54,9 @@ async function main() {
       console.log('Dry run only. Re-run with --execute to apply updates.');
       console.log('Sample (up to 10):');
       for (const row of affected.slice(0, 10)) {
-        console.log(`  ${row.id}  ${row.email}  user=${row.user_email_verified}  profile=${row.profile_is_email_verified}`);
+        console.log(
+          `  ${row.id}  ${row.email}  user=${row.user_email_verified}  profile=${row.profile_is_email_verified}`
+        );
       }
       return;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users can get stuck behind the **Verify your Email** modal even though their auth user is already verified (e.g. after Google OAuth).

Example from production (`test@gmail.com`):

| Table | Field | Value |
|-------|-------|-------|
| `user` | `email_verified` | `true` |
| `profile` | `is_email_verified` | `false` |

The dashboard gates on `profile.is_email_verified`, but `POST /send-verification-email` checks the auth `user` table and returns:

```json
{ "code": "EMAIL_IS_ALREADY_VERIFIED", "message": "Email is already verified" }
```

Production dry-run count: **970** affected profiles.

## Root cause

Email verification lives in two places:

- **Better Auth `user.email_verified`** — set by Google OAuth / verification links
- **`profile.is_email_verified`** — what the dashboard reads

Sync only ran on `user.update`, so legacy users and returning Google logins could keep a stale `profile` flag forever.

## Fix

1. **`syncProfileEmailVerificationFromAuthUser`** — query-layer helper that aligns `profile.is_email_verified` with `user.email_verified` and linked OAuth/SSO accounts.
2. **Run sync on session create/update** — repairs stale rows on every login.
3. **Run sync in `getAccountData`** — repairs on account fetch (page load / app init).
4. **`createProfileHook`** — when a profile already exists, promote `is_email_verified` if auth/OAuth says verified.
5. **`VerifyEmailModal`** — treat session `emailVerified` as verified; if send-verification-email returns `EMAIL_IS_ALREADY_VERIFIED`, refetch account to sync the profile store.

## One-time backfill (970 users)

```bash
# Dry run
pnpm db:backfill-profile-email-verification

# Apply
pnpm db:backfill-profile-email-verification -- --execute
```

Requires `DATABASE_URL` in `packages/db/.env` (or env). Script reports updated count and verifies zero mismatches remain.

## Testing

- `pnpm --filter @cio/api build` passes
- `pnpm format:changed` applied to touched files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0df642f-72bf-49fe-b403-a824093f125e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0df642f-72bf-49fe-b403-a824093f125e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR syncs email verification state between Better Auth and profiles. The main changes are:

- Adds a shared helper to promote stale profile verification from auth users or linked providers.
- Runs the sync on session create, session update, and account fetch.
- Updates profile creation to promote existing profiles when auth says the email is verified.
- Updates the verify-email modal to use session verification and refresh account data.
- Adds a backfill script and docs for existing stale rows.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/queries/auth/profile.ts | Adds the central promote-only sync helper for auth/profile email verification. |
| packages/db/src/auth.ts | Runs profile verification sync after session create and update. |
| packages/db/src/auth/hooks/create-profile.ts | Promotes existing profiles when auth or linked providers show the email is verified. |
| apps/api/src/services/account/profile.ts | Syncs verification before returning account profile data. |
| apps/dashboard/src/lib/features/onboarding/components/verify-email-modal.svelte | Uses session verification state and refetches account data after already-verified responses. |
| packages/db/src/scripts/backfill-profile-email-verification.ts | Adds a dry-run and execute script to repair existing stale profile verification rows. |

<sub>Reviews (3): Last reviewed commit: ["fix(auth): promote user.email\_verified w..."](https://github.com/classroomio/classroomio/commit/822c1c89ba763ba5ae16100892b507c6066ff7c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43474029)</sub>

<!-- /greptile_comment -->