### PR TITLE
fix(auth): strip internal port from OAuth redirects on BYOD domains

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,12 @@ import { isPublicCorsPath, sessionCors } from '@api/middlewares/cors';
 import { randomBytes } from 'crypto';
 
 import { API_SERVER_URL } from '@api/constants';
+import {
+  resolveOAuthBrowserOrigin,
+  rewriteAuthRequestUrl,
+  rewriteOAuthProxyCallbackLocation,
+  shouldRewriteOAuthProxyCallbackLocation
+} from '@api/utils/oauth-proxy-redirect';
 import { Hono } from '@api/utils/hono';
 import { ErrorCodes } from '@api/utils/errors';
 import { accountRouter } from '@api/routes/account';
@@ -114,13 +120,16 @@ export const app = new Hono()
     let request = c.req.raw;
     const fwdHost = c.req.header('x-forwarded-host');
     const fwdProto = c.req.header('x-forwarded-proto');
+    const browserOrigin = resolveOAuthBrowserOrigin({
+      forwardedHost: fwdHost,
+      forwardedProto: fwdProto
+    });
+
     if (fwdHost) {
-      const url = new URL(request.url);
-      url.host = fwdHost;
-      if (fwdProto === 'https' || fwdProto === 'http') {
-        url.protocol = `${fwdProto}:`;
-      }
-      request = new Request(url, request);
+      request = rewriteAuthRequestUrl(request, {
+        forwardedHost: fwdHost,
+        forwardedProto: fwdProto
+      });
     }
 
     // Inbound: if the browser is hitting `/oauth-proxy-callback?token=…`
@@ -168,8 +177,9 @@ export const app = new Hono()
     // pushes the Location header past Render's response size ceiling and
     // the redirect silently never reaches the browser.
     if (response.status >= 300 && response.status < 400) {
-      const location = response.headers.get('location');
-      if (location && location.includes('/oauth-proxy-callback') && location.includes('cookies=')) {
+      let location = response.headers.get('location');
+
+      if (location?.includes('/oauth-proxy-callback') && location.includes('cookies=')) {
         try {
           const outUrl = new URL(location);
           const cookies = outUrl.searchParams.get('cookies');
@@ -178,13 +188,21 @@ export const app = new Hono()
             await storeHandoffPayload(token, cookies);
             outUrl.searchParams.delete('cookies');
             outUrl.searchParams.set('token', token);
-            const headers = new Headers(response.headers);
-            headers.set('location', outUrl.toString());
-            return new Response(response.body, { status: response.status, headers });
+            location = outUrl.toString();
           }
         } catch (error) {
           console.error('[auth-handler] failed to swap cookies → token, falling back to inline cookies:', error);
         }
+      }
+
+      if (location && browserOrigin && shouldRewriteOAuthProxyCallbackLocation(location, browserOrigin)) {
+        location = rewriteOAuthProxyCallbackLocation(location, browserOrigin);
+      }
+
+      if (location && location !== response.headers.get('location')) {
+        const headers = new Headers(response.headers);
+        headers.set('location', location);
+        return new Response(response.body, { status: response.status, headers });
       }
     }
 

--- a/apps/api/src/utils/__tests__/oauth-proxy-redirect.test.ts
+++ b/apps/api/src/utils/__tests__/oauth-proxy-redirect.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  resolveOAuthBrowserOrigin,
+  rewriteAuthRequestUrl,
+  rewriteOAuthProxyCallbackLocation,
+  shouldRewriteOAuthProxyCallbackLocation,
+  stripBackendPortFromHost
+} from '../oauth-proxy-redirect';
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('stripBackendPortFromHost', () => {
+  it('removes a port that matches PRIVATE_SERVER_URL', () => {
+    process.env.PRIVATE_SERVER_URL = 'http://cio-api-vymh:10000';
+
+    expect(stripBackendPortFromHost('my.fastlearner.io:10000')).toBe('my.fastlearner.io');
+  });
+
+  it('keeps non-backend ports such as local dev', () => {
+    process.env.PRIVATE_SERVER_URL = 'http://localhost:3002';
+
+    expect(stripBackendPortFromHost('localhost:5173')).toBe('localhost:5173');
+  });
+});
+
+describe('rewriteAuthRequestUrl', () => {
+  it('clears the internal upstream port from the rewritten request URL', () => {
+    process.env.PRIVATE_SERVER_URL = 'http://cio-api-vymh:10000';
+
+    const request = new Request('http://cio-api-vymh:10000/api/auth/sign-in/social', { method: 'POST' });
+    const rewritten = rewriteAuthRequestUrl(request, {
+      forwardedHost: 'my.fastlearner.io',
+      forwardedProto: 'https'
+    });
+
+    expect(new URL(rewritten.url).href).toBe('https://my.fastlearner.io/api/auth/sign-in/social');
+  });
+});
+
+describe('resolveOAuthBrowserOrigin', () => {
+  it('prefers x-forwarded-host without the backend port', () => {
+    process.env.PRIVATE_SERVER_URL = 'http://cio-api-vymh:10000';
+
+    expect(
+      resolveOAuthBrowserOrigin({
+        forwardedHost: 'my.fastlearner.io:10000',
+        forwardedProto: 'https'
+      })
+    ).toBe('https://my.fastlearner.io');
+  });
+
+  it('falls back to DASHBOARD_ORIGIN when forwarded host is absent', () => {
+    process.env.DASHBOARD_ORIGIN = 'https://my.fastlearner.io';
+
+    expect(resolveOAuthBrowserOrigin({})).toBe('https://my.fastlearner.io');
+  });
+});
+
+describe('rewriteOAuthProxyCallbackLocation', () => {
+  it('rewrites backend host to the public dashboard origin', () => {
+    const location =
+      'https://my.fastlearner.io:10000/api/auth/oauth-proxy-callback?callbackURL=https%3A%2F%2Fmy.fastlearner.io%2Fcourse%2Ffoo%2Fenroll&token=abc';
+
+    expect(shouldRewriteOAuthProxyCallbackLocation(location, 'https://my.fastlearner.io')).toBe(true);
+    expect(rewriteOAuthProxyCallbackLocation(location, 'https://my.fastlearner.io')).toBe(
+      'https://my.fastlearner.io/api/auth/oauth-proxy-callback?callbackURL=https%3A%2F%2Fmy.fastlearner.io%2Fcourse%2Ffoo%2Fenroll&token=abc'
+    );
+  });
+});

--- a/apps/api/src/utils/__tests__/oauth-proxy-redirect.test.ts
+++ b/apps/api/src/utils/__tests__/oauth-proxy-redirect.test.ts
@@ -40,6 +40,18 @@ describe('rewriteAuthRequestUrl', () => {
 
     expect(new URL(rewritten.url).href).toBe('https://my.fastlearner.io/api/auth/sign-in/social');
   });
+
+  it('strips a backend port from x-forwarded-host before rewriting the request URL', () => {
+    process.env.PRIVATE_SERVER_URL = 'http://cio-api-vymh:10000';
+
+    const request = new Request('http://cio-api-vymh:10000/api/auth/sign-in/social', { method: 'POST' });
+    const rewritten = rewriteAuthRequestUrl(request, {
+      forwardedHost: 'my.fastlearner.io:10000',
+      forwardedProto: 'https'
+    });
+
+    expect(new URL(rewritten.url).href).toBe('https://my.fastlearner.io/api/auth/sign-in/social');
+  });
 });
 
 describe('resolveOAuthBrowserOrigin', () => {

--- a/apps/api/src/utils/oauth-proxy-redirect.ts
+++ b/apps/api/src/utils/oauth-proxy-redirect.ts
@@ -11,18 +11,19 @@
 
 function readBackendPorts(): Set<number> {
   const ports = new Set<number>();
+  const privateServerUrl = process.env.PRIVATE_SERVER_URL?.trim();
 
-  for (const value of [process.env.PRIVATE_SERVER_URL, process.env.PUBLIC_SERVER_URL]) {
-    if (!value?.trim()) continue;
+  if (!privateServerUrl) {
+    return ports;
+  }
 
-    try {
-      const parsed = new URL(value.trim());
-      if (parsed.port) {
-        ports.add(Number(parsed.port));
-      }
-    } catch {
-      // Ignore malformed env values.
+  try {
+    const parsed = new URL(privateServerUrl);
+    if (parsed.port) {
+      ports.add(Number(parsed.port));
     }
+  } catch {
+    // Ignore malformed env values.
   }
 
   return ports;

--- a/apps/api/src/utils/oauth-proxy-redirect.ts
+++ b/apps/api/src/utils/oauth-proxy-redirect.ts
@@ -1,0 +1,117 @@
+/**
+ * Better Auth's `oAuthProxy` plugin redirects the browser to
+ * `{host}/api/auth/oauth-proxy-callback` on the host that initiated OAuth.
+ *
+ * BYOD custom domains reach the API through the dashboard's internal proxy
+ * (`PRIVATE_SERVER_URL`, often `http://service:10000`). Node's URL setter keeps
+ * the upstream port unless it is cleared explicitly — e.g. `url.host =
+ * 'my.fastlearner.io'` on a `http://cio-api-vymh:10000/...` request still
+ * yields `https://my.fastlearner.io:10000/...`.
+ */
+
+function readBackendPorts(): Set<number> {
+  const ports = new Set<number>();
+
+  for (const value of [process.env.PRIVATE_SERVER_URL, process.env.PUBLIC_SERVER_URL]) {
+    if (!value?.trim()) continue;
+
+    try {
+      const parsed = new URL(value.trim());
+      if (parsed.port) {
+        ports.add(Number(parsed.port));
+      }
+    } catch {
+      // Ignore malformed env values.
+    }
+  }
+
+  return ports;
+}
+
+/** Strip a backend/API port when it appears on a browser-facing host header. */
+export function stripBackendPortFromHost(host: string): string {
+  const [hostname, portValue] = host.includes(':') ? host.split(':', 2) : [host, ''];
+  if (!portValue || !hostname) return host;
+
+  const port = Number(portValue);
+  if (!Number.isFinite(port) || !readBackendPorts().has(port)) {
+    return host;
+  }
+
+  return hostname;
+}
+
+/** Public origin where the browser should complete the oauth-proxy handoff. */
+export function resolveOAuthBrowserOrigin(options: {
+  forwardedHost?: string | null;
+  forwardedProto?: string | null;
+}): string | null {
+  const dashboardOrigin = process.env.DASHBOARD_ORIGIN?.trim().replace(/\/$/, '');
+
+  if (options.forwardedHost) {
+    const proto =
+      options.forwardedProto === 'http' || options.forwardedProto === 'https' ? options.forwardedProto : 'https';
+    const host = stripBackendPortFromHost(options.forwardedHost);
+
+    return `${proto}://${host}`;
+  }
+
+  if (dashboardOrigin) {
+    return dashboardOrigin;
+  }
+
+  return null;
+}
+
+/**
+ * Rebuild the auth request URL from proxy headers so Better Auth sees the
+ * browser-facing host without the internal upstream port.
+ */
+export function rewriteAuthRequestUrl(
+  request: Request,
+  options: { forwardedHost?: string | null; forwardedProto?: string | null }
+): Request {
+  const { forwardedHost, forwardedProto } = options;
+  if (!forwardedHost?.trim()) {
+    return request;
+  }
+
+  const url = new URL(request.url);
+  const publicHost = stripBackendPortFromHost(forwardedHost.trim());
+  const [hostname, explicitPort = ''] = publicHost.includes(':') ? publicHost.split(':', 2) : [publicHost, ''];
+
+  url.hostname = hostname!;
+  url.port = explicitPort;
+
+  if (forwardedProto === 'https' || forwardedProto === 'http') {
+    url.protocol = `${forwardedProto}:`;
+  }
+
+  return new Request(url, request);
+}
+
+export function shouldRewriteOAuthProxyCallbackLocation(location: string, browserOrigin: string): boolean {
+  if (!location.includes('/oauth-proxy-callback')) {
+    return false;
+  }
+
+  try {
+    const target = new URL(location);
+    const origin = new URL(browserOrigin.endsWith('/') ? browserOrigin : `${browserOrigin}/`);
+
+    return target.host !== origin.host || target.protocol !== origin.protocol;
+  } catch {
+    return false;
+  }
+}
+
+export function rewriteOAuthProxyCallbackLocation(location: string, browserOrigin: string): string {
+  const target = new URL(location);
+  const origin = new URL(browserOrigin.endsWith('/') ? browserOrigin : `${browserOrigin}/`);
+
+  target.protocol = origin.protocol;
+  target.hostname = origin.hostname;
+  target.port = origin.port;
+
+  return target.toString();
+}

--- a/apps/dashboard/src/lib/utils/proxy-api-request.ts
+++ b/apps/dashboard/src/lib/utils/proxy-api-request.ts
@@ -34,8 +34,27 @@ function resolveApiUpstreamBase(): string | null {
   return base.replace(/\/$/, '');
 }
 
-function resolveOriginalHost(request: Request, url: URL): string {
-  return request.headers.get('x-forwarded-host') ?? request.headers.get('host') ?? url.host;
+function resolveBrowserForwardedHost(request: Request, url: URL): string {
+  const raw = request.headers.get('x-forwarded-host') ?? request.headers.get('host') ?? url.hostname;
+  const [hostname, port = ''] = raw.includes(':') ? raw.split(':', 2) : [raw, ''];
+
+  if (!port) {
+    return hostname;
+  }
+
+  const privateServerUrl = process.env.PRIVATE_SERVER_URL;
+  if (privateServerUrl) {
+    try {
+      const backendPort = new URL(privateServerUrl).port;
+      if (backendPort && port === backendPort) {
+        return hostname;
+      }
+    } catch {
+      // Ignore malformed PRIVATE_SERVER_URL.
+    }
+  }
+
+  return raw;
 }
 
 export async function proxyRequestToApi(request: Request): Promise<Response> {
@@ -49,7 +68,7 @@ export async function proxyRequestToApi(request: Request): Promise<Response> {
 
   const upstreamPath = resolveApiUpstreamPath(url.pathname);
   const upstreamUrl = new URL(`${upstreamPath}${url.search}`, apiBase);
-  const originalHost = resolveOriginalHost(request, url);
+  const originalHost = resolveBrowserForwardedHost(request, url);
 
   const upstreamHeaders = new Headers(request.headers);
   upstreamHeaders.set('host', upstreamUrl.host);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Google OAuth redirecting to `https://customer-domain:10000/...` on BYOD custom domains (e.g. `my.fastlearner.io`).

**Root cause:** BYOD domains reach the API through the dashboard's internal proxy (`PRIVATE_SERVER_URL=http://cio-api-vymh:10000`). When Better Auth rebuilds callback URLs from `X-Forwarded-Host`, Node's `url.host = 'my.fastlearner.io'` setter does **not** clear the upstream port — the browser is redirected to `:10000`.

Subdomain tenants (`*.myclassroomio.com`) were unaffected because the Cloudflare tenant-router forwards directly to the public API host without an internal port.

## Changes

- **`apps/api/src/utils/oauth-proxy-redirect.ts`** — helpers to strip backend ports, rewrite inbound auth request URLs (`hostname` + explicit `port = ''`), and rewrite outbound `oauth-proxy-callback` Location headers to the browser-facing origin
- **`apps/api/src/app.ts`** — use `rewriteAuthRequestUrl()` instead of `url.host = fwdHost`; rewrite oauth-proxy callback redirects when host/protocol mismatch
- **`apps/dashboard/src/lib/utils/proxy-api-request.ts`** — send hostname-only `X-Forwarded-Host` when the port matches `PRIVATE_SERVER_URL`
- **Tests** — `oauth-proxy-redirect.test.ts` covers port stripping and URL rewriting

## Greptile review addressed

- `readBackendPorts()` now only reads `PRIVATE_SERVER_URL` (not `PUBLIC_SERVER_URL`)
- Added test for `rewriteAuthRequestUrl` when `X-Forwarded-Host` still carries `:10000`

## Testing

- `pnpm --filter @cio/api exec vitest run src/utils/__tests__/oauth-proxy-redirect.test.ts` — 7 tests pass
- `pnpm --filter @cio/api build` — passes

## Notes

- Supersedes #725 (revert of `layout-setup.ts` hostname fix) — the real fix is explicit port clearing, not reverting the hostname change
- `PUBLIC_SERVER_URL` should remain `https://api.classroomio.com` (not customer domain, not `/proxy`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-627d2c91-c091-4912-bb15-45359d3e8b6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-627d2c91-c091-4912-bb15-45359d3e8b6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Google OAuth redirecting browsers to `https://customer-domain:10000/...` on BYOD custom domains by explicitly clearing the internal backend port when rebuilding auth request URLs from `X-Forwarded-Host`. The root cause was Node's `URL.host` setter not clearing the upstream port, so the fix switches to setting `url.hostname` + `url.port = ''` separately.

- **`oauth-proxy-redirect.ts`** — new module with helpers to strip backend ports from host headers, resolve the public browser-facing OAuth origin, rewrite inbound auth request URLs, and rewrite outbound `oauth-proxy-callback` Location headers when the host/protocol still point at the internal upstream.
- **`app.ts`** — replaces the one-liner `url.host = fwdHost` with `rewriteAuthRequestUrl()` and adds outbound Location rewriting for oauth-proxy-callback redirects so both legs of the handoff land on the correct public domain.
- **`proxy-api-request.ts`** — dashboard proxy now strips the backend port from `X-Forwarded-Host` before forwarding, providing a defence-in-depth layer on the sending side.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix precisely targets the internal-port leak by switching to separate hostname and port setters and adding a matching outbound Location rewrite, without touching unrelated auth logic.

All changed code paths are well-tested with 7 new unit tests including the defence-in-depth port-on-forwardedHost case. The rewrite logic is narrow in scope, only oauth-proxy-callback redirects are touched on the outbound side, and existing behaviour for subdomain tenants is unchanged.

No files require special attention. The two suggestions in oauth-proxy-redirect.ts are optional improvements, not blocking concerns.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/oauth-proxy-redirect.ts | New utility module with four exported helpers to strip internal backend ports from browser-facing hosts, resolve the public OAuth browser origin, rewrite inbound auth request URLs, and rewrite outbound oauth-proxy-callback Location headers. Logic is sound; env reads happen via readBackendPorts() on each invocation. |
| apps/api/src/app.ts | Replaces url.host = fwdHost with rewriteAuthRequestUrl() and adds outbound Location-header rewriting for oauth-proxy-callback redirects; the two separate 3xx status blocks are slightly redundant but logically correct because the first returns early on any modification. |
| apps/dashboard/src/lib/utils/proxy-api-request.ts | Renamed helper strips the backend port before forwarding x-forwarded-host; last-resort URL fallback changed from url.host to url.hostname with no practical impact since HTTP clients always send a Host header. |
| apps/api/src/utils/__tests__/oauth-proxy-redirect.test.ts | New test file with 7 cases covering port stripping, URL rewriting with and without a backend port already in x-forwarded-host, browser origin resolution, and Location header rewriting. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Dashboard as Dashboard SvelteKit
    participant API as API Hono BetterAuth
    participant Google

    Browser->>Dashboard: GET /api/auth/sign-in/social
    Note over Dashboard: resolveBrowserForwardedHost strips :10000
    Dashboard->>API: POST to cio-api-vymh:10000 with X-Forwarded-Host my.fastlearner.io
    Note over API: rewriteAuthRequestUrl sets hostname plus clears port
    API->>Google: Redirect with callback https://my.fastlearner.io/api/auth/callback/google
    Google-->>Browser: Redirect to callback URL
    Browser->>Dashboard: "GET /api/auth/callback/google?code=abc"
    Dashboard->>API: Forwards to cio-api-vymh:10000
    Note over API: Better Auth validates code and emits raw Location with :10000
    Note over API: shouldRewriteOAuthProxyCallbackLocation detects mismatch then rewrites host
    API-->>Browser: "302 to my.fastlearner.io/api/auth/oauth-proxy-callback?token=abc"
    Browser->>Dashboard: "GET /api/auth/oauth-proxy-callback?token=abc"
    Dashboard->>API: Forwards token
    API-->>Browser: Session established
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Dashboard as Dashboard SvelteKit
    participant API as API Hono BetterAuth
    participant Google

    Browser->>Dashboard: GET /api/auth/sign-in/social
    Note over Dashboard: resolveBrowserForwardedHost strips :10000
    Dashboard->>API: POST to cio-api-vymh:10000 with X-Forwarded-Host my.fastlearner.io
    Note over API: rewriteAuthRequestUrl sets hostname plus clears port
    API->>Google: Redirect with callback https://my.fastlearner.io/api/auth/callback/google
    Google-->>Browser: Redirect to callback URL
    Browser->>Dashboard: "GET /api/auth/callback/google?code=abc"
    Dashboard->>API: Forwards to cio-api-vymh:10000
    Note over API: Better Auth validates code and emits raw Location with :10000
    Note over API: shouldRewriteOAuthProxyCallbackLocation detects mismatch then rewrites host
    API-->>Browser: "302 to my.fastlearner.io/api/auth/oauth-proxy-callback?token=abc"
    Browser->>Dashboard: "GET /api/auth/oauth-proxy-callback?token=abc"
    Dashboard->>API: Forwards token
    API-->>Browser: Session established
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(auth): address Greptile review on oa..."](https://github.com/classroomio/classroomio/commit/a05d5b53798bbb4d5e5f4bbf1b1a28862e772071) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43396426)</sub>

<!-- /greptile_comment -->