### PR TITLE
fix(website): cache GitHub stars on server for 3 hours

### DIFF
--- a/apps/website/src/lib/server/github-stars.ts
+++ b/apps/website/src/lib/server/github-stars.ts
@@ -1,0 +1,68 @@
+const GITHUB_REPO_URL = 'https://api.github.com/repos/classroomio/classroomio';
+const CACHE_TTL_MS = 1000 * 60 * 60 * 3;
+
+const starsCache = {
+  stars: 0,
+  lastUpdated: 0
+};
+
+let inFlightFetch: Promise<number> | null = null;
+
+function isCacheFresh(now: number) {
+  return starsCache.lastUpdated > 0 && now - starsCache.lastUpdated < CACHE_TTL_MS;
+}
+
+export async function getGithubStars(): Promise<number> {
+  const now = Date.now();
+
+  if (isCacheFresh(now)) {
+    return starsCache.stars;
+  }
+
+  if (inFlightFetch) {
+    return inFlightFetch;
+  }
+
+  inFlightFetch = fetchGithubStars(now).finally(() => {
+    inFlightFetch = null;
+  });
+
+  return inFlightFetch;
+}
+
+async function fetchGithubStars(now: number): Promise<number> {
+  try {
+    const response = await fetch(GITHUB_REPO_URL, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'classroomio-website'
+      }
+    });
+
+    if (!response.ok) {
+      console.error('getGithubStars error: GitHub API returned', response.status);
+
+      if (starsCache.lastUpdated > 0) {
+        return starsCache.stars;
+      }
+
+      return 0;
+    }
+
+    const data = await response.json();
+    const stars = typeof data?.stargazers_count === 'number' ? data.stargazers_count : 0;
+
+    starsCache.stars = stars;
+    starsCache.lastUpdated = now;
+
+    return stars;
+  } catch (error) {
+    console.error('getGithubStars error:', error);
+
+    if (starsCache.lastUpdated > 0) {
+      return starsCache.stars;
+    }
+
+    return 0;
+  }
+}

--- a/apps/website/src/routes/+layout.server.ts
+++ b/apps/website/src/routes/+layout.server.ts
@@ -1,0 +1,7 @@
+import { getGithubStars } from '$lib/server/github-stars';
+
+export async function load() {
+  const stars = await getGithubStars();
+
+  return { stars };
+}

--- a/apps/website/src/routes/+layout.ts
+++ b/apps/website/src/routes/+layout.ts
@@ -3,49 +3,17 @@ import type { MetaTagsProps } from 'svelte-meta-tags';
 export const prerender = true;
 
 export async function load({ url }) {
-  const stars = await getStars();
-
   return {
     baseMetaTags: getBaseMetaTags(url),
-    url: url.pathname,
-    stars
+    url: url.pathname
   };
 }
 
-const starsCache = new Map<string, { stars: number; lastUpdated: number }>();
-const CACHE_TIME = 1000 * 60 * 60 * 48; // 48 hours
-const CACHE_KEY = 'github-stars';
 const DEFAULT_META_TITLE = 'ClassroomIO | One Platform for Customer, Partner, and Employee Training';
 const DEFAULT_META_DESCRIPTION =
   'One platform for customer academies, partner certification, and employee training. Build courses with AI, publish under your domain, and track completions.';
 const DEFAULT_OG_IMAGE_URL = 'https://brand.cdn.clsrio.com/og/classroomio-opengraph.jpg';
 const DEFAULT_OG_IMAGE_ALT = 'ClassroomIO platform for customer, partner, and employee education';
-
-async function getStars() {
-  const now = Date.now();
-
-  const cacheData = starsCache.get(CACHE_KEY);
-  if (cacheData && now - cacheData.lastUpdated < CACHE_TIME) {
-    console.log('Returning cached stars');
-    return cacheData.stars;
-  }
-
-  console.log('Fetching stars from GitHub');
-
-  let stars = 0;
-
-  try {
-    const response = await fetch('https://api.github.com/repos/classroomio/classroomio');
-    const data = await response.json();
-    stars = data?.stargazers_count || 0;
-  } catch (error) {
-    console.log('error fetching stars', error);
-  }
-
-  starsCache.set(CACHE_KEY, { stars, lastUpdated: now });
-
-  return stars;
-}
 
 function getBaseMetaTags(url: URL) {
   const canonicalUrl = new URL(url.pathname, url.origin).href;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes GitHub API rate limiting on the marketing website by moving star-count fetching to server-only code with a 3-hour in-memory cache.

## Problem

`+layout.ts` fetched `https://api.github.com/repos/classroomio/classroomio` on every layout load. Because this was a universal load function, it could run on both server and client, and SSR routes like `/pricing` (`prerender = false`) hit the API on every request — quickly exhausting the unauthenticated GitHub rate limit.

## Solution

- Move star fetching to `+layout.server.ts` (server-only, never runs in the browser)
- Add `src/lib/server/github-stars.ts` with a simple in-memory cache object and a **3-hour TTL**
- Deduplicate concurrent requests with an in-flight promise so parallel page loads only trigger one API call
- On API errors (including rate limits), return the last successfully cached value when available

## Testing

- `pnpm --filter @cio/website build` passes
- `pnpm format:check` passes

## Notes

On Cloudflare Workers each isolate maintains its own cache, so the first request per isolate after a cold start may still call GitHub once. Within a warm worker, subsequent requests are served from cache for 3 hours. For a higher rate limit, a `GITHUB_TOKEN` could be added later as a follow-up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ac0c08b-2fcc-441f-8e71-0c2bb611feeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ac0c08b-2fcc-441f-8e71-0c2bb611feeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves GitHub star fetching into server-only website code. The main changes are:

- Adds a server helper with a 3-hour in-memory cache.
- Deduplicates concurrent GitHub API requests with one in-flight promise.
- Moves `stars` into the root server layout data.
- Removes GitHub fetching from the universal layout load.

<h3>Confidence Score: 4/5</h3>

The prerendered layout path can freeze the star count at build time.

- The new server helper avoids browser-side GitHub calls.
- The root server load can still execute during prerendering, so many pages may not use the runtime cache.
- The cache fallback mostly handles failures, but one unexpected OK payload can cache `0` temporarily.

apps/website/src/routes/+layout.server.ts and apps/website/src/lib/server/github-stars.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/src/lib/server/github-stars.ts | Adds the server-only GitHub fetch helper, cache state, TTL check, request deduplication, and stale-on-error fallback. |
| apps/website/src/routes/+layout.server.ts | Adds a root server load that returns the cached GitHub star count. |
| apps/website/src/routes/+layout.ts | Keeps metadata generation in the universal load and removes the GitHub star fetch. |

<sub>Reviews (1): Last reviewed commit: ["fix(website): cache GitHub stars on serv..."](https://github.com/classroomio/classroomio/commit/37c334044763ac975776827cdb7c54f336226714) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43551446)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->