### PR TITLE
fix(org): route admin and tutor invites to app domain

### DIFF
--- a/apps/api/src/services/organization/invite.ts
+++ b/apps/api/src/services/organization/invite.ts
@@ -28,7 +28,7 @@ import { ROLE } from '@cio/utils/constants';
 import type { TNewOrganizationInviteAudit } from '@db/types';
 import crypto from 'node:crypto';
 import { db, type DbOrTxClient } from '@cio/db/drizzle';
-import { getDashboardBaseUrl } from '@cio/core/config/dashboard-url';
+import { getAppBaseUrl } from '@cio/core/config/dashboard-url';
 import { parseCourseIdsFromInviteMetadata, parseCohortIdsFromInviteMetadata } from '@api/utils/org';
 import { markUserAndProfileEmailVerified } from '@cio/db/queries/auth/profile';
 import { enqueueTransactionalEmail } from '@api/services/jobs';
@@ -61,11 +61,8 @@ function normalizeEmails(emails: string[]): string[] {
   return [...new Set(emails.map((email) => email.toLowerCase().trim()).filter(Boolean))];
 }
 
-function buildInviteLink(
-  token: string,
-  org?: { siteName?: string | null; customDomain?: string | null; isCustomDomainVerified?: boolean | null }
-): string {
-  return `${getDashboardBaseUrl(org)}/invite/${encodeURIComponent(token)}`;
+function buildTeamInviteLink(token: string): string {
+  return `${getAppBaseUrl()}/invite/${encodeURIComponent(token)}`;
 }
 
 function getRoleLabel(roleId: number): string {
@@ -249,7 +246,7 @@ export async function inviteTeamMembers(orgId: string, emails: string[], roleId:
         }
       });
 
-      const inviteLink = buildInviteLink(token, organization);
+      const inviteLink = buildTeamInviteLink(token);
 
       try {
         await enqueueTransactionalEmail('inviteTeacher', {

--- a/apps/dashboard/src/lib/features/settings/pages/teams.svelte
+++ b/apps/dashboard/src/lib/features/settings/pages/teams.svelte
@@ -4,7 +4,7 @@
   import CopyIcon from '@lucide/svelte/icons/copy';
 
   import { profile } from '$lib/utils/store/user';
-  import { isFreePlan, currentOrg } from '$lib/utils/store/org';
+  import { getAppOrigin, isFreePlan, currentOrg } from '$lib/utils/store/org';
   import { orgApi } from '$features/org/api/org.svelte';
   import { t } from '$lib/utils/functions/translations';
   import { snackbar } from '$features/ui/snackbar/store';
@@ -25,7 +25,7 @@
   let isRemoving: number | null = $state(null);
 
   function buildLinkInviteUrl(token: string): string {
-    return `${window.location.origin}/invite/link/${encodeURIComponent(token)}`;
+    return `${getAppOrigin()}/invite/link/${encodeURIComponent(token)}`;
   }
 
   async function onCopyInviteLink() {

--- a/apps/dashboard/src/lib/utils/store/org.ts
+++ b/apps/dashboard/src/lib/utils/store/org.ts
@@ -6,7 +6,7 @@ import type { AccountOrg } from '$features/app/types';
 import type { OrgTeamMember } from '../types/org';
 import { canUsePublicApi, isOrgOnFreePlan, PLAN } from '@cio/utils/plans';
 import { PUBLIC_IS_SELFHOSTED } from '$env/static/public';
-import { ROLE, TENANT_ROOT_DOMAIN } from '@cio/utils/constants';
+import { BRAND_ROOT_DOMAIN, ROLE, TENANT_ROOT_DOMAIN } from '@cio/utils/constants';
 import { STEPS } from '../constants/quiz';
 import type { Writable } from 'svelte/store';
 
@@ -78,6 +78,18 @@ export const currentOrgPath = derived(currentOrg, ($currentOrg) =>
 );
 
 type OrgPublicOrigin = Pick<AccountOrg, 'customDomain' | 'isCustomDomainVerified' | 'siteName'>;
+
+/**
+ * Admin dashboard origin (`app.classroomio.com` in cloud). Use for team invite links
+ * and other admin-only URLs — not student-facing tenant pages.
+ */
+export function getAppOrigin(): string {
+  if (PUBLIC_IS_SELFHOSTED === 'true' || dev) {
+    return browser ? window.location.origin : '';
+  }
+
+  return `https://app.${BRAND_ROOT_DOMAIN}`;
+}
 
 /**
  * Public origin for an org's tenant site (student LMS, public course pages, login-link handoff).

--- a/packages/core/src/config/dashboard-url.ts
+++ b/packages/core/src/config/dashboard-url.ts
@@ -46,3 +46,11 @@ export function getDashboardBaseUrl(org?: DashboardOrg): string {
 
   return `https://app.${BRAND_ROOT_DOMAIN}`;
 }
+
+/**
+ * Returns the admin dashboard origin (`app.classroomio.com` in cloud).
+ * Use for team-member invite links (admin/tutor) — not student-facing URLs.
+ */
+export function getAppBaseUrl(): string {
+  return getDashboardBaseUrl();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes team member (admin/tutor) invite URLs pointing at the org's custom domain or tenant subdomain instead of the admin dashboard (`app.classroomio.com`).

**Before:** Inviting a teacher from `app.classroomio.com` sent an email with a link like `https://my.fastlearner.io/invite/...`.

**After:** Admin and tutor invite emails and copied link-invite URLs always use the app origin (`app.classroomio.com` in cloud, `DASHBOARD_ORIGIN` or localhost in self-hosted/dev).

Student org invites are unchanged — they still use the org's verified custom domain or `siteName.myclassroomio.com`.

## Changes

- Added `getAppBaseUrl()` in `@cio/core/config/dashboard-url` for admin-dashboard URLs (no org tenant context).
- Team invite emails (`inviteTeamMembers`) now build links with `getAppBaseUrl()` instead of `getDashboardBaseUrl(org)`.
- Link-invite copy in Settings → Team uses new `getAppOrigin()` instead of `window.location.origin`.

## Test plan

- [ ] From an org with a verified custom domain, invite a tutor by email — link should be `https://app.classroomio.com/invite/...`
- [ ] Copy a team link invite from Settings → Team — URL should use `app.classroomio.com`, not the custom domain
- [ ] Student audience/org invite emails still use the org custom domain or `siteName.myclassroomio.com`
- [ ] Self-hosted: team invite links still use `DASHBOARD_ORIGIN` / current origin
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c83985a-29f6-47c3-8c9e-c274e354ae85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c83985a-29f6-47c3-8c9e-c274e354ae85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes team invite links to the admin app domain instead of org tenant domains. The main changes are:

- Adds shared app-origin helpers for API and dashboard code.
- Sends admin and tutor email invites through the app dashboard origin.
- Copies team link invites with the app dashboard origin.
- Leaves org public/student invite URL handling on the tenant origin path.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/services/organization/invite.ts | Team invite email links now use the app base URL helper. |
| apps/dashboard/src/lib/features/settings/pages/teams.svelte | Copied team invite links now use the shared app-origin helper. |
| apps/dashboard/src/lib/utils/store/org.ts | Adds an app-origin helper while keeping org public origin handling separate. |
| packages/core/src/config/dashboard-url.ts | Adds a no-org app base URL helper for admin dashboard links. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into cursor/fix-team..."](https://github.com/classroomio/classroomio/commit/54416d05828fa53e335d65e87948004b01ad9683) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43557973)</sub>

<!-- /greptile_comment -->