### PR TITLE
fix(dashboard): stop rendering mode-watcher init script as visible page text

### DIFF
--- a/apps/dashboard/src/lib/features/app/app-mode-watcher.svelte
+++ b/apps/dashboard/src/lib/features/app/app-mode-watcher.svelte
@@ -1,19 +1,8 @@
 <script lang="ts">
   import { browser } from '$app/environment';
-  import {
-    ModeWatcher,
-    createInitialModeExpression,
-    setMode,
-    systemPrefersMode,
-    userPrefersMode
-  } from '@cio/ui/base/dark-mode';
+  import { ModeWatcher, setMode, systemPrefersMode, userPrefersMode } from '@cio/ui/base/dark-mode';
 
-  import { MODE_STORAGE_KEY, readStoredColorMode } from '$lib/utils/functions/color-mode';
-
-  const initialModeScript = createInitialModeExpression({
-    defaultMode: 'light',
-    modeStorageKey: MODE_STORAGE_KEY
-  });
+  import { readStoredColorMode } from '$lib/utils/functions/color-mode';
 
   $effect(() => {
     if (!browser) {
@@ -29,9 +18,4 @@
   });
 </script>
 
-<svelte:head>
-  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-  {@html initialModeScript}
-</svelte:head>
-
-<ModeWatcher defaultMode="light" disableHeadScriptInjection />
+<ModeWatcher defaultMode="light" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Hotfix — visible JavaScript on customer org sites

**Severity: production**

Customer sites (e.g. `belajarkumon.myclassroomio.com`) are showing raw `setInitialMode` source code at the top of every page after #738 merged.

### Root cause (#738)

`createInitialModeExpression()` returns **bare JavaScript**, not a `<script>` element. `AppModeWatcher` injected it via `{@html}` in `<svelte:head>`, which rendered the function body as visible page text instead of executing it.

```svelte
<!-- broken in #738 -->
{@html initialModeScript}
<ModeWatcher disableHeadScriptInjection />
```

### Fix

Remove the manual `{@html}` injection. Use `<ModeWatcher defaultMode="light" />` so mode-watcher wraps the init snippet in a proper `<script>` tag.

Theme preference behavior from #738 is unchanged (sidebar light/dark/system, no forced light routes).

### Verify after deploy

1. Open any org-site course landing page — **no** raw JS at the top
2. Sidebar theme toggle still works

---

Rebased on latest `main` (`8288f157b`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-627d2c91-c091-4912-bb15-45359d3e8b6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-627d2c91-c091-4912-bb15-45359d3e8b6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the dashboard mode watcher so the init script is no longer rendered as page text.

- Removes the manual `createInitialModeExpression` HTML injection.
- Drops the unused mode storage key import from this component.
- Lets `ModeWatcher` inject its own head script with `defaultMode="light"`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/app/app-mode-watcher.svelte | Replaces manual raw HTML injection with the library-managed `ModeWatcher` script path. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): stop rendering mode-watc..."](https://github.com/classroomio/classroomio/commit/4631504fcbc416d9b99240f670567a6409cecb17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43653462)</sub>

<!-- /greptile_comment -->