### PR TITLE
fix(dashboard): redirect to course start after auto-enroll

### DIFF
--- a/apps/dashboard/src/lib/features/course/utils/student-course-navigation.ts
+++ b/apps/dashboard/src/lib/features/course/utils/student-course-navigation.ts
@@ -1,0 +1,3 @@
+export function getStudentCourseContinuePath(courseId: string): string {
+  return `/courses/${courseId}/lessons?next=true`;
+}

--- a/apps/dashboard/src/lib/features/lms/components/learning.svelte
+++ b/apps/dashboard/src/lib/features/lms/components/learning.svelte
@@ -13,10 +13,11 @@
     getStudentCourseComplianceStatusVariant,
     getStudentCourseProgressPercent
   } from '$features/course/utils/compliance-utils';
+  import { getStudentCourseContinuePath } from '$features/course/utils/student-course-navigation';
 
   const gotoCourse = (id: string | undefined) => {
     if (!id) return;
-    goto(`/courses/${id}/lessons?next=true`);
+    goto(getStudentCourseContinuePath(id));
   };
 
   let highlightedCourses = $derived.by(() => {

--- a/apps/dashboard/src/lib/features/lms/pages/dashboard.svelte
+++ b/apps/dashboard/src/lib/features/lms/pages/dashboard.svelte
@@ -35,6 +35,7 @@
     getStudentCourseProgressPercent,
     isStudentCourseComplete
   } from '$features/course/utils/compliance-utils';
+  import { getStudentCourseContinuePath } from '$features/course/utils/student-course-navigation';
 
   type EnrolledCourse = (typeof coursesApi.enrolledCourses)[number];
 
@@ -147,7 +148,7 @@
   function gotoCourse(id: string | undefined) {
     if (!id) return;
 
-    goto(`/courses/${id}/lessons?next=true`);
+    goto(getStudentCourseContinuePath(id));
   }
 
   function gotoCourseCertificates(id: string | undefined) {

--- a/apps/dashboard/src/routes/(org-site)/course/[slug]/enroll/+page.svelte
+++ b/apps/dashboard/src/routes/(org-site)/course/[slug]/enroll/+page.svelte
@@ -13,6 +13,7 @@
   import { resolve } from '$app/paths';
   import { authClient } from '$lib/utils/services/auth/client';
   import { appInitApi } from '$features/app/init.svelte';
+  import { getStudentCourseContinuePath } from '$features/course/utils/student-course-navigation';
 
   let { data } = $props();
 
@@ -27,19 +28,6 @@
   const sessionUser = $derived($session.data?.user ?? null);
   const isLoggedIn = $derived(sessionReady && Boolean(sessionUser));
   const isEmailVerified = $derived(Boolean($profile.isEmailVerified || sessionUser?.emailVerified));
-
-  function resolvePostEnrollRedirect(enrollResult: { redirectTo?: string } | undefined): string {
-    if (enrollResult?.redirectTo) {
-      return enrollResult.redirectTo;
-    }
-
-    const slug = data.course?.slug;
-    if (slug) {
-      return `/course/${slug}`;
-    }
-
-    return '/lms';
-  }
 
   async function sendVerificationEmail() {
     const email = $profile.email || sessionUser?.email;
@@ -150,7 +138,7 @@
       }
 
       navigatingAway = true;
-      window.location.href = resolvePostEnrollRedirect(result.data);
+      await goto(resolve(getStudentCourseContinuePath(data.course.id), {}));
     } finally {
       enrollmentInFlight = false;
       if (!navigatingAway) {

--- a/apps/dashboard/src/routes/(org-site)/course/[slug]/enroll/+page.svelte
+++ b/apps/dashboard/src/routes/(org-site)/course/[slug]/enroll/+page.svelte
@@ -28,7 +28,16 @@
   const isLoggedIn = $derived(sessionReady && Boolean(sessionUser));
   const isEmailVerified = $derived(Boolean($profile.isEmailVerified || sessionUser?.emailVerified));
 
-  function resolvePostEnrollRedirect(): string {
+  function resolvePostEnrollRedirect(enrollResult: { redirectTo?: string } | undefined): string {
+    if (enrollResult?.redirectTo) {
+      return enrollResult.redirectTo;
+    }
+
+    const slug = data.course?.slug;
+    if (slug) {
+      return `/course/${slug}`;
+    }
+
     return '/lms';
   }
 
@@ -141,7 +150,7 @@
       }
 
       navigatingAway = true;
-      window.location.href = resolvePostEnrollRedirect();
+      window.location.href = resolvePostEnrollRedirect(result.data);
     } finally {
       enrollmentInFlight = false;
       if (!navigatingAway) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After a logged-in user auto-enrolls on the org-site course enroll page, they were sent to `/lms` instead of into the course.

## Changes

- Add `getStudentCourseContinuePath()` — the same `/courses/:id/lessons?next=true` path used by LMS Continue
- After successful enroll (verified email), navigate with `goto()` to that path instead of a hard reload to `/lms` or `/course/:slug`
- Reuse the helper in LMS dashboard/learning so both flows stay aligned

## Test plan

- [ ] Log in as a verified student on an org site
- [ ] Visit `/course/{slug}/enroll` for a free, open course
- [ ] Confirm auto-enroll redirects to the same place as clicking Continue on `/lms`
- [ ] Confirm unverified users still remain on the enroll page with the verify-email prompt
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2a98ed7-7a1a-460c-b885-89446157228e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2a98ed7-7a1a-460c-b885-89446157228e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR sends enrolled students directly into their course after auto-enroll. The main changes are:

- Added a shared helper for the course continue URL.
- Reused that helper in LMS continue navigation.
- Changed org-site enrollment success to navigate to the course lessons page.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/course/utils/student-course-navigation.ts | Adds a shared helper for the existing LMS course continue path. |
| apps/dashboard/src/lib/features/lms/components/learning.svelte | Replaces inline continue URL construction with the shared helper. |
| apps/dashboard/src/lib/features/lms/pages/dashboard.svelte | Replaces dashboard course navigation URL construction with the shared helper. |
| apps/dashboard/src/routes/(org-site)/course/[slug]/enroll/+page.svelte | Redirects verified auto-enrolled users to the course lessons continue path. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): match LMS continue path ..."](https://github.com/classroomio/classroomio/commit/ac966e3f8045a0141bde451583c2e69be82f696c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43679088)</sub>

<!-- /greptile_comment -->