### PR TITLE
fix(dashboard): make course list rows openable in new tabs

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/course-list-row.svelte
+++ b/apps/dashboard/src/lib/features/course/components/course-list-row.svelte
@@ -5,6 +5,7 @@
   import { Badge } from '@cio/ui/base/badge';
   import { Button } from '@cio/ui/base/button';
   import EllipsisVerticalIcon from '@lucide/svelte/icons/ellipsis-vertical';
+  import { cn } from '@cio/ui/tools';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { ContentType } from '@cio/utils/constants/content';
@@ -114,31 +115,55 @@
     return `Updated ${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`;
   });
 
+  const courseUrl = $derived.by(() => {
+    if (isExplore && onExploreClick) {
+      return undefined;
+    }
+
+    if (isExplore) {
+      if (!slug.trim()) {
+        return undefined;
+      }
+
+      return resolve(`/course/${slug}`, {});
+    }
+
+    if (isLMS) {
+      return resolve(`/courses/${id}/lessons?next=true`, {});
+    }
+
+    return resolve(`/courses/${id}`, {});
+  });
+
   function handleRowClick() {
     if (isExplore && onExploreClick) {
       onExploreClick();
       return;
     }
-    if (isExplore) {
-      goto(resolve(`/course/${slug}`, {}));
+
+    if (!courseUrl) {
       return;
     }
-    if (isLMS) {
-      goto(resolve(`/courses/${id}/lessons?next=true`, {}));
+
+    goto(courseUrl);
+  }
+
+  function handleRowKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Enter' && event.key !== ' ') {
       return;
     }
-    goto(resolve(`/courses/${id}`, {}));
+
+    event.preventDefault();
+    handleRowClick();
+  }
+
+  function stopRowNavigation(event: MouseEvent) {
+    event.preventDefault();
+    event.stopPropagation();
   }
 </script>
 
-<ResourceListRow.Root
-  variant="default"
-  size="sm"
-  align="start"
-  class="cursor-pointer py-4!"
-  onclick={handleRowClick}
-  role="row"
->
+{#snippet rowContent()}
   <div
     class="grid w-full grid-cols-1 items-start gap-x-3 gap-y-2 @3xl:grid-cols-[var(--row-cols)]"
     style="--row-cols: {gridTemplateColumns}"
@@ -265,8 +290,8 @@
           <Button
             variant="outline"
             size="sm"
-            onclick={(e) => {
-              e.stopPropagation();
+            onclick={(event) => {
+              stopRowNavigation(event);
               onExploreClick?.();
             }}
           >
@@ -282,7 +307,7 @@
                   size="icon"
                   class="size-8"
                   aria-label={$t('courses.course_card.actions_menu_aria')}
-                  onclick={(e) => e.stopPropagation()}
+                  onclick={stopRowNavigation}
                 >
                   <EllipsisVerticalIcon class="size-4" />
                 </Button>
@@ -317,4 +342,25 @@
       </div>
     {/if}
   </div>
+{/snippet}
+
+<ResourceListRow.Root variant="default" size="sm" align="start" class="cursor-pointer py-4!">
+  {#snippet child({ props })}
+    {#if courseUrl}
+      <a href={courseUrl} {...props} class={cn('block', props.class as string)}>
+        {@render rowContent()}
+      </a>
+    {:else}
+      <div
+        {...props}
+        class={cn('block', props.class as string)}
+        role="button"
+        tabindex="0"
+        onclick={handleRowClick}
+        onkeydown={handleRowKeydown}
+      >
+        {@render rowContent()}
+      </div>
+    {/if}
+  {/snippet}
 </ResourceListRow.Root>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The org courses page supports grid (cards) and list (horizontal row) layouts. Card rows were real `<a>` links, but list rows used `onclick` + `goto()`, so right-click / open-in-new-tab did not work.

This change wraps list-view course rows in anchor tags with the same destination URLs as the card layout.

## Changes

- Compute a `courseUrl` for each list row (org course, LMS lesson, or public explore URL)
- Render the row as an `<a href="...">` when a URL is available
- Keep button-style behavior only when a custom `onExploreClick` handler is provided (e.g. LMS dashboard preview modal)
- Prevent action buttons and context menus from triggering navigation when clicked inside the link

## Testing

- [ ] Open org → Courses, switch to list layout
- [ ] Right-click a course row → "Open link in new tab" works
- [ ] Cmd/Ctrl+click opens course in a new tab
- [ ] Context menu (⋯) still works without navigating
- [ ] Grid layout behavior unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53c2b121-d428-4119-8735-c5f7032ed1dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53c2b121-d428-4119-8735-c5f7032ed1dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes list-view course rows behave like links. The main changes are:

- Adds a derived course URL for org, LMS, and explore rows.
- Renders linked list rows as anchors when a URL exists.
- Keeps custom explore click handling on non-link rows.
- Stops nested action controls from navigating the row.

<h3>Confidence Score: 4/5</h3>

The linked row flow is mostly contained, but the dropdown trigger path needs a fix before merging.

- Row URLs are computed in the expected org, LMS, and explore cases.
- The ellipsis trigger now receives a click handler that cancels the default click while it is nested inside the row link.
- That can keep the context menu from opening on linked list rows.

apps/dashboard/src/lib/features/course/components/course-list-row.svelte

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/course/components/course-list-row.svelte | Converts course list rows to anchors where possible, with one event-handling issue on the nested dropdown trigger. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): make course list rows re..."](https://github.com/classroomio/classroomio/commit/52e3c862a6ab535763b48f325ae8ef419d92019b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43684384)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->