### PR TITLE
fix(dashboard): keep enroll join button visible with loading state

### DIFF
--- a/apps/dashboard/src/routes/(org-site)/course/[slug]/enroll/+page.svelte
+++ b/apps/dashboard/src/routes/(org-site)/course/[slug]/enroll/+page.svelte
@@ -64,6 +64,14 @@
           data.course?.status === 'ACTIVE' &&
           Boolean(data.course?.isPublished)
   );
+  const isPreparingEnrollment = $derived(
+    isLoggedIn &&
+      canJoinCourse &&
+      !enrollmentSucceeded &&
+      !enrolledPendingVerification &&
+      !appInitApi.isInitializedAndReady
+  );
+  const joinButtonLoading = $derived(!sessionReady || loading || enrollmentInFlight || isPreparingEnrollment);
 
   function getBlockedMessage(): string {
     if (blocksNewSignup) {
@@ -211,13 +219,7 @@
   <meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
-<AuthUI
-  isLogin={false}
-  {handleSubmit}
-  isLoading={loading || !sessionReady || (isLoggedIn && canJoinCourse && enrollmentInFlight)}
-  showOnlyContent={true}
-  showLogo={true}
->
+<AuthUI isLogin={false} {handleSubmit} isLoading={joinButtonLoading} showOnlyContent={true} showLogo={true}>
   <div class="mt-0 w-full">
     <h3 class="mt-0 mb-4 text-center text-lg font-medium dark:text-white">{data.course?.title}</h3>
     <p class="text-center text-sm font-light dark:text-white">{data.course?.description}</p>
@@ -248,9 +250,9 @@
     {/if}
   </div>
 
-  {#if !enrolledPendingVerification && (!isLoggedIn || (isLoggedIn && canJoinCourse && !enrollmentInFlight))}
+  {#if !enrolledPendingVerification}
     <div class="my-4 flex w-full items-center justify-center">
-      <Button type="submit" disabled={!canJoinCourse || loading || !sessionReady || enrollmentInFlight} {loading}>
+      <Button type="submit" disabled={!canJoinCourse || joinButtonLoading} loading={joinButtonLoading}>
         {$t('course.navItem.landing_page.enroll_page.join_course')}
       </Button>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the enroll page UX where logged-in users saw no Join button while session verification, app initialization, or auto-enrollment were in progress.

## Problem

The Join Course button was conditionally hidden when:
- The user was logged in and auto-enrollment was running (`enrollmentInFlight`)
- The user was logged in but `canJoinCourse` was false (button hidden entirely for logged-in users)

This left logged-in visitors staring at an empty card with no primary action during the enroll flow.

## Solution

- Always render the Join Course button (except after successful enroll pending email verification, where the resend CTA is shown instead).
- Introduce `joinButtonLoading` derived state that covers session loading, app init preparation, and enrollment in flight.
- Drive the button `loading` and `disabled` props from that state so users see a spinner instead of a missing button.

## Test plan

- [ ] Open `/course/{slug}/enroll` while logged out — Join button visible; redirects to login/signup on click.
- [ ] Open while logged in — Join button visible immediately with loading spinner during session/app init/auto-enroll.
- [ ] Logged-in user with unverified email — after enroll succeeds, success copy + resend verification button shown.
- [ ] Blocked enroll states (payment required, invalid invite) — button visible but disabled with error message.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-627d2c91-c091-4912-bb15-45359d3e8b6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-627d2c91-c091-4912-bb15-45359d3e8b6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the course enroll page button behavior. The main changes are:

- Adds derived state for enrollment preparation and Join button loading.
- Passes the new loading state into `AuthUI`.
- Keeps the Join button rendered until pending email verification replaces it.
- Drives the Join button disabled and loading props from the shared loading state.

<h3>Confidence Score: 4/5</h3>

The changed enroll flow has one contained loading-state bug to fix before merging.

- The Join button can stay disabled forever when app initialization is non-ready after failure.
- The rest of the change is localized to the enroll page button rendering path.

apps/dashboard/src/routes/(org-site)/course/[slug]/enroll/+page.svelte

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/routes/(org-site)/course/[slug]/enroll/+page.svelte | Updates the enroll page Join button rendering and loading state, with a bug where app-init non-readiness can permanently disable the button. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): keep enroll join button ..."](https://github.com/classroomio/classroomio/commit/61e9152a1fa00c7574e42edede999f43574712ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43688074)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->