### PR TITLE
fix(dashboard): improve AI chat word wrapping readability

### DIFF
--- a/apps/dashboard/src/lib/features/ai-assistant/message-bubble.svelte
+++ b/apps/dashboard/src/lib/features/ai-assistant/message-bubble.svelte
@@ -137,7 +137,7 @@
   {:else}
     <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
     <div
-      class="max-w-[90%] rounded-lg px-3 py-2 text-sm {message.role === 'user'
+      class="max-w-[90%] min-w-0 rounded-lg px-3 py-2 text-sm {message.role === 'user'
         ? 'ui:bg-primary ui:text-primary-foreground'
         : 'ui:bg-muted'}"
       onclick={handleBubbleClick}
@@ -159,8 +159,8 @@
       {#each inlineParts as part, partIndex (partIndex)}
         {#if part.type === 'text'}
           <div
-            class="ai-chat-prose prose prose-sm dark:prose-invert max-w-none break-all {message.role === 'user' &&
-              'ui:text-primary-foreground!'}"
+            class="ai-chat-prose prose prose-sm dark:prose-invert max-w-none min-w-0 break-words {message.role ===
+              'user' && 'ui:text-primary-foreground!'}"
           >
             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
             {@html renderMentions(renderMarkdown(part.text as string), courseId)}
@@ -260,6 +260,17 @@
   /* Reset global `apps/dashboard/src/app.css` `.prose p { mb-4 }` for chat bubbles */
   :global(.ai-chat-prose.prose p) {
     margin-bottom: 0;
+  }
+
+  /* Normal prose wraps at word boundaries; only unbreakable runs (URLs, keys) split mid-token. */
+  :global(.ai-chat-prose.prose pre) {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  :global(.ai-chat-prose.prose :not(pre) > code),
+  :global(.ai-chat-prose.prose a) {
+    overflow-wrap: anywhere;
   }
 
   :global(.mention-link) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes awkward mid-word line breaks in AI chat messages caused by `break-all` on the message prose container.

## Problem

Chat bubbles used Tailwind `break-all` (`word-break: break-all`), which splits normal words at arbitrary characters whenever the line is near the container edge. That made assistant replies hard to read (e.g. "bridge" → "brid" / "ge").

## Approach

Use a layered wrapping strategy:

1. **Normal prose** — `break-words` so text wraps at spaces and only breaks inside a token when that token alone is wider than the bubble.
2. **Inline code & links** — `overflow-wrap: anywhere` so long API keys, URLs, and JWTs can still wrap without overflowing the bubble.
3. **Fenced code blocks** — `overflow-x: auto` so multi-line code scrolls horizontally instead of being chopped character-by-character.

Also added `min-w-0` on the bubble container so flex layout allows proper shrinking/wrapping.

## Testing

- [ ] Open AI assistant chat with a normal multi-sentence reply — words should stay intact at line breaks.
- [ ] Paste a long URL or API key — content should wrap or scroll without overflowing the bubble.
- [ ] Verify fenced code blocks scroll horizontally when wider than the panel.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dbce7eb-681c-4475-9387-e5bdbec1bc93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dbce7eb-681c-4475-9387-e5bdbec1bc93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves wrapping in AI assistant chat bubbles. The main changes are:

- Adds `min-w-0` to the message bubble and prose container.
- Replaces arbitrary mid-word prose breaks with word-boundary wrapping.
- Allows long inline code and links to wrap inside the bubble.
- Makes fenced code blocks scroll horizontally when wider than the panel.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/ai-assistant/message-bubble.svelte | Updates chat bubble classes and scoped prose CSS to improve wrapping for normal text, links, inline code, and fenced code blocks. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): improve AI chat word wra..."](https://github.com/classroomio/classroomio/commit/817ea44e544bd6cd30d124f6891580d04c8e7a57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43694023)</sub>

<!-- /greptile_comment -->